### PR TITLE
Remove subscription when cancel

### DIFF
--- a/Sources/OpenCombine/PassthroughSubject.swift
+++ b/Sources/OpenCombine/PassthroughSubject.swift
@@ -49,6 +49,12 @@ public final class PassthroughSubject<Output, Failure: Error>: Subject  {
             }
         }
     }
+    
+    private func _removeSubscription(_ subscription: Conduit) {
+        _lock.do {
+            _downstreams.removeAll(where: { $0 === subscription })
+        }
+    }
 }
 
 extension PassthroughSubject {
@@ -80,6 +86,8 @@ extension PassthroughSubject {
         }
 
         func cancel() {
+            _parent?._removeSubscription(self)
+            
             _parent = nil
             _downstream = nil
         }

--- a/Tests/OpenCombineTests/PassthroughSubjectTests.swift
+++ b/Tests/OpenCombineTests/PassthroughSubjectTests.swift
@@ -23,6 +23,7 @@ final class PassthroughSubjectTests: XCTestCase {
         ("testValuesAfterCompletion", testValuesAfterCompletion),
         ("testLifecycle", testLifecycle),
         ("testSynchronization", testSynchronization),
+        ("testShouldRemoveSubscriptionWhenCancel", testShouldRemoveSubscriptionWhenCancel)
     ]
 
     private typealias Sut = PassthroughSubject<Int, TestingError>

--- a/Tests/OpenCombineTests/PassthroughSubjectTests.swift
+++ b/Tests/OpenCombineTests/PassthroughSubjectTests.swift
@@ -367,4 +367,27 @@ final class PassthroughSubjectTests: XCTestCase {
 
         XCTAssertEqual(completions.count, 200)
     }
+    
+    func testShouldRemoveSubscriptionWhenCancel() {
+        
+        weak var subscription: AnyObject?
+        
+        let pub = PassthroughSubject<Int, Never>()
+        
+        let sub = AnySubscriber<Int, Never>(receiveSubscription: { (s) in
+            subscription = s as AnyObject
+            s.request(.max(1))
+        }, receiveValue: { _ in
+            return .none
+        }, receiveCompletion: { _ in
+        })
+        
+        pub.subscribe(sub)
+
+        XCTAssertNotNil(subscription)
+        
+        pub.send(completion: .finished)
+        
+        XCTAssertNil(subscription)
+    }
 }


### PR DESCRIPTION
`subscription` should be removed from `PassthroughSubject` when it is canceled.