### PR TITLE
Arrange class hierarchy for Inner helpers

### DIFF
--- a/Sources/OpenCombine/Publishers/OperatorSubscription.swift
+++ b/Sources/OpenCombine/Publishers/OperatorSubscription.swift
@@ -1,0 +1,24 @@
+//
+//  OperatorSubscription.swift
+//  
+//
+//  Created by Sergej Jaskiewicz on 26.06.2019.
+//
+
+internal class OperatorSubscription<Downstream: Subscriber>: CustomReflectable {
+    internal var downstream: Downstream
+    internal var upstreamSubscription: Subscription?
+
+    internal var customMirror: Mirror {
+        return Mirror(self, children: EmptyCollection())
+    }
+
+    internal init(downstream: Downstream) {
+        self.downstream = downstream
+    }
+
+    internal func cancel() {
+        upstreamSubscription?.cancel()
+        upstreamSubscription = nil
+    }
+}

--- a/Sources/OpenCombine/Publishers/Publishers.DropWhile.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.DropWhile.swift
@@ -24,10 +24,8 @@ extension Publishers {
         public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
             where Failure == SubscriberType.Failure, Output == SubscriberType.Input
         {
-            let dropWhile = _DropWhile<Upstream, SubscriberType, (Output) -> Bool>(
-                downstream: subscriber, predicate: predicate
-            )
-            upstream.receive(subscriber: dropWhile)
+            let inner = Inner(downstream: subscriber, predicate: catching(predicate))
+            upstream.receive(subscriber: inner)
         }
     }
 
@@ -48,88 +46,132 @@ extension Publishers {
         public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
             where Output == SubscriberType.Input, SubscriberType.Failure == Error
         {
-            let dropWhile = _DropWhile<Upstream, SubscriberType, (Output) throws -> Bool>(
-                downstream: subscriber, predicate: predicate
-            )
-
-            upstream.receive(subscriber: dropWhile)
+            let inner = Inner(downstream: subscriber, predicate: catching(predicate))
+            upstream.receive(subscriber: inner)
         }
     }
 }
 
-private final class _DropWhile<Upstream: Publisher, Downstream: Subscriber, Predicate>
-    : Subscriber,
+private class _DropWhile<Upstream: Publisher, Downstream: Subscriber>
+    : OperatorSubscription<Downstream>,
       CustomStringConvertible,
-      CustomReflectable,
       Subscription
-          where Upstream.Output == Downstream.Input
+    where Upstream.Output == Downstream.Input
 {
-
-    typealias Input = Downstream.Input
+    typealias Input = Upstream.Output
     typealias Failure = Upstream.Failure
+    typealias Predicate = (Input) -> Result<Bool, Downstream.Failure>
 
-    private var _downstream: Downstream
-    private let _predicate: (Input) throws -> Bool
-    private var _predicateReturnedFalse = false
-    private var _upstreamSubscription: Subscription?
-    private var _demand: Subscribers.Demand = .none
+    /// The predicate is reset to `nil` as soon as it returns `false`.
+    var predicate: Predicate?
+
+    var demand: Subscribers.Demand = .none
+
+    init(downstream: Downstream, predicate: @escaping Predicate) {
+        self.predicate = predicate
+        super.init(downstream: downstream)
+    }
 
     var description: String { return "DropWhile" }
 
-    var customMirror: Mirror { return Mirror(self, children: EmptyCollection()) }
-
-    init(downstream: Downstream, predicate: @escaping (Input) throws -> Bool) {
-        _downstream = downstream
-        _predicate = predicate
-    }
-
     func receive(subscription: Subscription) {
-        _upstreamSubscription = subscription
+        upstreamSubscription = subscription
+
+        // NOTE: until the predicate returns false, we will ask the upstream publisher
+        // for elements one by one, no matter how much elements the downstream subscriber
+        // requests.
+        //
+        // However, IF the downstream requests anything, we accumulate this demand in the
+        // `demand` property so that later we can provide the downstream with the correct
+        // amount of values.
+        //
+        // As soon as the predicate returns false, we switch to the mode where
+        // we just forward all the requests from the downstream to the upstream.
         subscription.request(.max(1))
-        _downstream.receive(subscription: self)
+
+        downstream.receive(subscription: self)
     }
 
     func receive(_ input: Input) -> Subscribers.Demand {
 
-        if _predicateReturnedFalse {
-            return _downstream.receive(input)
+        guard let predicate = self.predicate else {
+            return downstream.receive(input)
         }
 
-        do {
-            if try !_predicate(input) {
-                _predicateReturnedFalse = true
-                return _demand + _downstream.receive(input) - 1
-            } else {
-                return .max(1)
-            }
-        } catch {
-            // Safe to force unwrap here — predicate throws only if we're within
-            // a TryDropWhile, and its (and its downstream's) Failure type is always
-            // plain Error
-            _downstream.receive(completion: .failure(error as! Downstream.Failure))
+        switch predicate(input) {
+        case .success(true):
+            // See the NOTE above to understand why we return .max(1)
+            return .max(1)
+        case .success(false):
+            // Okay, we hit the first element not satisfying the predicate,
+            // from now on we just republish the values to the downstream.
+            self.predicate = nil
+
+            // The demand that the downstream has requested has been accumulated in the
+            // `demand` property. Now it's time to pay the debt.
+            //
+            // Subtracting 1 for the current value.
+            return demand + downstream.receive(input) - 1
+        case .failure(let error):
+            downstream.receive(completion: .failure(error))
             cancel()
             return .none
         }
     }
 
-    func receive(completion: Subscribers.Completion<Failure>) {
-        switch completion {
-        case .finished:
-            _downstream.receive(completion: .finished)
-        case .failure(let error):
-            // Safe to force unwrap here, since Downstream.Failure can be
-            // either Upstream.Failure or Error
-            _downstream.receive(completion: .failure(error as! Downstream.Failure))
+    func request(_ demand: Subscribers.Demand) {
+        if predicate == nil {
+            // If predicate is nil, that means that we have already received a value
+            // that doesn't satisfy the predicate, hence we're in the state where we
+            // just forward each request to the upstream.
+            upstreamSubscription?.request(demand)
+        } else {
+            // Otherwise, as mentioned in the NOTE above, we accumulate all the demand
+            // requested by the downstream until the predicate returns false.
+            self.demand += demand
         }
     }
+}
 
-    func request(_ demand: Subscribers.Demand) {
-        _demand = demand
+extension Publishers.DropWhile {
+
+    private final class Inner<Downstream: Subscriber>
+        : _DropWhile<Upstream, Downstream>,
+          Subscriber
+        where Upstream.Output == Downstream.Input, Downstream.Failure == Upstream.Failure
+    {
+        func receive(completion: Subscribers.Completion<Failure>) {
+            downstream.receive(completion: completion)
+        }
     }
+}
 
-    func cancel() {
-        _upstreamSubscription?.cancel()
-        _upstreamSubscription = nil
+extension Publishers.TryDropWhile {
+
+    private final class Inner<Downstream: Subscriber>
+        : _DropWhile<Upstream, Downstream>,
+           Subscriber
+        where Upstream.Output == Downstream.Input, Downstream.Failure == Error
+    {
+        func receive(completion: Subscribers.Completion<Failure>) {
+            // The `completion` argument has the type
+            // `Subscribers.Completion<Upstream.Failure>`, and
+            // the `downstream.receive(completion:)` method expects
+            // `Subscribers.Completion<Error>`.
+            //
+            // Since user-defined generic types in Swift are invariant relative to their
+            // generic parameters, `Subscribers.Completion<Upstream.Failure>` is not
+            // a subtype of `Subscribers.Completion<Error>` and therefore cannot be passed
+            // where the latter is expected.
+            //
+            // So we need to destructure `completion` explicitly in this switch.
+            switch completion {
+            case .finished:
+                downstream.receive(completion: .finished)
+            case .failure(let error):
+                downstream.receive(completion: .failure(error))
+            }
+        }
     }
 }
 

--- a/Sources/OpenCombine/Result.swift
+++ b/Sources/OpenCombine/Result.swift
@@ -44,3 +44,19 @@ extension Result where Failure == Never {
         }
     }
 }
+
+/// An overload of `catching` that takes a non-thowing function and returns
+/// a function that returns an always succeeding `Result.`
+internal func catching<Input, Output, Failure: Error>(
+    _ transform: @escaping (Input) -> Output
+) -> (Input) -> Result<Output, Failure> {
+    return { input in .success(transform(input)) }
+}
+
+/// Takes a function that may throw an error and returns a function that doesn't throw
+/// an error but returns `Result`.
+internal func catching<Input, Output>(
+    _ transform: @escaping (Input) throws -> Output
+    ) -> (Input) -> Result<Output, Error> {
+    return { input in Result { try transform(input) } }
+}

--- a/Tests/OpenCombineTests/PublisherTests/DropWhileTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/DropWhileTests.swift
@@ -20,7 +20,8 @@ final class DropWhileTests: XCTestCase {
 
     static let allTests = [
         ("testDropWhile", testDropWhile),
-        ("testTryDropWhile", testTryDropWhile),
+        ("testTryDropWhileFailureBecauseOfThrow", testTryDropWhileFailureBecauseOfThrow),
+        ("testTryDropWhileFailureOnCompletion", testTryDropWhileFailureOnCompletion),
         ("testDemand", testDemand),
         ("testTryDropWhileCancelsUpstreamOnThrow",
          testTryDropWhileCancelsUpstreamOnThrow),
@@ -56,7 +57,7 @@ final class DropWhileTests: XCTestCase {
         XCTAssertEqual(counter, 4)
     }
 
-    func testTryDropWhile() {
+    func testTryDropWhileFailureBecauseOfThrow() {
 
         var counter = 0 // How many times the predicate is called?
 
@@ -87,6 +88,23 @@ final class DropWhileTests: XCTestCase {
         XCTAssertEqual(counter, 3)
     }
 
+    func testTryDropWhileFailureOnCompletion() {
+
+        let publisher = PassthroughSubject<Int, Error>()
+        let drop = publisher.tryDrop { $0.isMultiple(of: 2) }
+
+        let tracking = TrackingSubscriberBase<Error>()
+
+        publisher.send(1)
+        drop.subscribe(tracking)
+        publisher.send(completion: .failure(TestingError.oops))
+        publisher.send(2)
+
+        XCTAssertEqual(tracking.history,
+                       [.subscription(Subscriptions.empty),
+                        .completion(.failure(TestingError.oops))])
+    }
+
     func testDemand() {
 
         let subscription = CustomSubscription()
@@ -104,6 +122,7 @@ final class DropWhileTests: XCTestCase {
         drop.subscribe(tracking)
 
         XCTAssertNotNil(downstreamSubscription)
+        dump(type(of: downstreamSubscription!))
 
         XCTAssertEqual(subscription.history, [.requested(.max(1))])
 
@@ -113,17 +132,28 @@ final class DropWhileTests: XCTestCase {
         XCTAssertEqual(publisher.send(2), .max(1))
         XCTAssertEqual(subscription.history, [.requested(.max(1))])
 
-        XCTAssertEqual(publisher.send(3), .max(45))
+        downstreamSubscription?.request(.max(95))
+        downstreamSubscription?.request(.max(5))
         XCTAssertEqual(subscription.history, [.requested(.max(1))])
+
+        XCTAssertEqual(publisher.send(3), .max(145)) // 145 = 42 + 95 + 5 + 3
+        XCTAssertEqual(subscription.history, [.requested(.max(1))])
+
+        downstreamSubscription?.request(.max(121))
+        XCTAssertEqual(subscription.history, [.requested(.max(1)), .requested(.max(121))])
 
         XCTAssertEqual(publisher.send(7), .max(4))
-        XCTAssertEqual(subscription.history, [.requested(.max(1))])
+        XCTAssertEqual(subscription.history, [.requested(.max(1)), .requested(.max(121))])
 
         downstreamSubscription?.cancel()
         downstreamSubscription?.cancel()
-        XCTAssertEqual(subscription.history, [.requested(.max(1)), .canceled])
+        XCTAssertEqual(subscription.history, [.requested(.max(1)),
+                                              .requested(.max(121)),
+                                              .canceled])
         downstreamSubscription?.request(.max(50))
-        XCTAssertEqual(subscription.history, [.requested(.max(1)), .canceled])
+        XCTAssertEqual(subscription.history, [.requested(.max(1)),
+                                              .requested(.max(121)),
+                                              .canceled])
 
         XCTAssertEqual(publisher.send(8), .max(4))
     }


### PR DESCRIPTION
What's in this PR:

- when implementing helper subscription classes (`Inner`) for operators, there was a lot of code duplication. I attempted to extract the common pieces into base classes (@spadafiva you may want to take a look)
- tweaked the `DropWhile` implementation to match Apple's Combine behavior when requesting elements using a `Subscription` instance
