### PR TITLE
Implement TryMap

### DIFF
--- a/RemainingCombineInterface.swift
+++ b/RemainingCombineInterface.swift
@@ -3687,20 +3687,6 @@ extension Publishers.Last : Equatable where Upstream : Equatable {
     public static func == (lhs: Publishers.Last<Upstream>, rhs: Publishers.Last<Upstream>) -> Bool
 }
 
-extension Publishers.Map {
-
-    public func map<T>(_ transform: @escaping (Output) -> T) -> Publishers.Map<Upstream, T>
-
-    public func tryMap<T>(_ transform: @escaping (Output) throws -> T) -> Publishers.TryMap<Upstream, T>
-}
-
-extension Publishers.TryMap {
-
-    public func map<T>(_ transform: @escaping (Output) -> T) -> Publishers.TryMap<Upstream, T>
-
-    public func tryMap<T>(_ transform: @escaping (Output) throws -> T) -> Publishers.TryMap<Upstream, T>
-}
-
 extension Publishers.Sequence {
 
     public func allSatisfy(_ predicate: (Publishers.Sequence<Elements, Failure>.Output) -> Bool) -> Publishers.Once<Bool, Failure>

--- a/Sources/OpenCombine/Publishers/Publishers.Map.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Map.swift
@@ -147,23 +147,7 @@ extension Publishers.TryMap {
         where Downstream.Failure == Error
     {
         func receive(completion: Subscribers.Completion<Failure>) {
-            // The `completion` argument has the type
-            // `Subscribers.Completion<Upstream.Failure>`, and
-            // the `downstream.receive(completion:)` method expects
-            // `Subscribers.Completion<Error>`.
-            //
-            // Since user-defined generic types in Swift are invariant relative to their
-            // generic parameters, `Subscribers.Completion<Upstream.Failure>` is not
-            // a subtype of `Subscribers.Completion<Error>` and therefore cannot be passed
-            // where the latter is expected.
-            //
-            // So we need to destructure `completion` explicitly in this switch.
-            switch completion {
-            case .finished:
-                downstream.receive(completion: .finished)
-            case .failure(let error):
-                downstream.receive(completion: .failure(error))
-            }
+            downstream.receive(completion: completion.eraseError())
         }
     }
 }

--- a/Sources/OpenCombine/Publishers/Publishers.Map.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Map.swift
@@ -11,11 +11,28 @@ extension Publisher {
     ///
     /// - Parameter transform: A closure that takes one element as its parameter and
     ///   returns a new element.
-    /// - Returns: A publisher that uses the provided closure to map elements from the
-    ///   upstream publisher to new elements that it then publishes.
-    public func map<Result>(_ transform: @escaping (Output) -> Result)
-        -> Publishers.Map<Self, Result> {
-            return Publishers.Map(upstream: self, transform: transform)
+    /// - Returns: A publisher that uses the provided closure to map elements from
+    ///   the upstream publisher to new elements that it then publishes.
+    public func map<Result>(
+        _ transform: @escaping (Output) -> Result
+    ) -> Publishers.Map<Self, Result> {
+        return Publishers.Map(upstream: self, transform: transform)
+    }
+
+    /// Transforms all elements from the upstream publisher with a provided
+    /// error-throwing closure.
+    ///
+    /// If the `transform` closure throws an error, the publisher fails with the thrown
+    /// error.
+    ///
+    /// - Parameter transform: A closure that takes one element as its parameter and
+    ///   returns a new element.
+    /// - Returns: A publisher that uses the provided closure to map elements from
+    ///   the upstream publisher to new elements that it then publishes.
+    public func tryMap<Result>(
+        _ transform: @escaping (Self.Output) throws -> Result
+    ) -> Publishers.TryMap<Self, Result> {
+        return Publishers.TryMap(upstream: self, transform: transform)
     }
 }
 
@@ -24,9 +41,6 @@ extension Publishers {
     /// a provided closure.
     public struct Map<Upstream: Publisher, Output> : Publisher {
 
-        /// The kind of errors this publisher might publish.
-        ///
-        /// Use `Never` if this `Publisher` does not publish errors.
         public typealias Failure = Upstream.Failure
 
         /// The publisher from which this publisher receives elements.
@@ -35,63 +49,121 @@ extension Publishers {
         /// The closure that transforms elements from the upstream publisher.
         public let transform: (Upstream.Output) -> Output
     }
+
+    /// A publisher that transforms all elements from the upstream publisher
+    /// with a provided error-throwing closure.
+    public struct TryMap<Upstream: Publisher, Output>: Publisher {
+
+        public typealias Failure = Error
+
+        /// The publisher from which this publisher receives elements.
+        public let upstream: Upstream
+
+        /// The error-throwing closure that transforms elements from
+        /// the upstream publisher.
+        public let transform: (Upstream.Output) throws -> Output
+    }
 }
 
 extension Publishers.Map {
     public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
-        where Output == SubscriberType.Input,
-        Upstream.Failure == SubscriberType.Failure {
-            let inner = Inner<Upstream, SubscriberType>(
-                downstream: subscriber, transform: transform
-            )
-            upstream.receive(subscriber: inner)
+        where Output == SubscriberType.Input, SubscriberType.Failure == Upstream.Failure
+    {
+        let inner = Inner(downstream: subscriber, transform: catching(transform))
+        upstream.receive(subscriber: inner)
     }
 }
 
-private final class Inner<Upstream: Publisher, Downstream: Subscriber>
-    : Subscriber,
-      Subscription {
-    typealias Input = Upstream.Output
-    typealias Failure = Downstream.Failure
-    typealias Transform = (Input) -> Downstream.Input
+extension Publishers.TryMap {
 
-    private let _downstream: Downstream
-    private var _upstreamSubscription: Subscription?
+    public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
+        where Output == SubscriberType.Input, SubscriberType.Failure == Error
+    {
+        let inner = Inner(downstream: subscriber, transform: catching(transform))
+        upstream.receive(subscriber: inner)
+    }
+}
+
+private class _Map<Upstream: Publisher, Downstream: Subscriber>
+    : OperatorSubscription<Downstream>,
+      CustomStringConvertible,
+      Subscription
+{
+    typealias Input = Upstream.Output
+    typealias Failure = Upstream.Failure
+    typealias Transform = (Input) -> Result<Downstream.Input, Downstream.Failure>
+
     private let _transform: Transform
 
     init(downstream: Downstream, transform: @escaping Transform) {
-        _downstream = downstream
         _transform = transform
+        super.init(downstream: downstream)
     }
 
+    var description: String { return "Map" }
+
     func receive(subscription: Subscription) {
-        _upstreamSubscription = subscription
-        _downstream.receive(subscription: self)
+        upstreamSubscription = subscription
+        downstream.receive(subscription: self)
     }
 
     func receive(_ input: Input) -> Subscribers.Demand {
-        return _downstream.receive(_transform(input))
-    }
-
-    func receive(completion: Subscribers.Completion<Failure>) {
-        _downstream.receive(completion: completion)
+        switch _transform(input) {
+        case .success(let output):
+            return downstream.receive(output)
+        case .failure(let error):
+            downstream.receive(completion: .failure(error))
+            return .none
+        }
     }
 
     func request(_ demand: Subscribers.Demand) {
-        _upstreamSubscription?.request(demand)
+        upstreamSubscription?.request(demand)
     }
 
-    func cancel() {
+    override func cancel() {
         _upstreamSubscription?.cancel()
     }
 }
 
-// MARK: - CustomStringConvertible
-extension Inner: CustomStringConvertible {
-    public var description: String { return "Map" }
+extension Publishers.Map {
+
+    private final class Inner<Downstream: Subscriber>
+        : _Map<Upstream, Downstream>,
+          Subscriber
+        where Downstream.Failure == Upstream.Failure
+    {
+        func receive(completion: Subscribers.Completion<Failure>) {
+            downstream.receive(completion: completion)
+        }
+    }
 }
 
-// MARK: - CustomReflectable
-extension Inner: CustomReflectable {
-    public var customMirror: Mirror { return Mirror(self, children: EmptyCollection()) }
+extension Publishers.TryMap {
+
+    private final class Inner<Downstream: Subscriber>
+        : _Map<Upstream, Downstream>,
+          Subscriber
+        where Downstream.Failure == Error
+    {
+        func receive(completion: Subscribers.Completion<Failure>) {
+            // The `completion` argument has the type
+            // `Subscribers.Completion<Upstream.Failure>`, and
+            // the `downstream.receive(completion:)` method expects
+            // `Subscribers.Completion<Error>`.
+            //
+            // Since user-defined generic types in Swift are invariant relative to their
+            // generic parameters, `Subscribers.Completion<Upstream.Failure>` is not
+            // a subtype of `Subscribers.Completion<Error>` and therefore cannot be passed
+            // where the latter is expected.
+            //
+            // So we need to destructure `completion` explicitly in this switch.
+            switch completion {
+            case .finished:
+                downstream.receive(completion: .finished)
+            case .failure(let error):
+                downstream.receive(completion: .failure(error))
+            }
+        }
+    }
 }

--- a/Sources/OpenCombine/Publishers/Publishers.Map.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Map.swift
@@ -66,21 +66,45 @@ extension Publishers {
 }
 
 extension Publishers.Map {
-    public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
-        where Output == SubscriberType.Input, SubscriberType.Failure == Upstream.Failure
+    public func receive<Downstream: Subscriber>(subscriber: Downstream)
+        where Output == Downstream.Input, Downstream.Failure == Upstream.Failure
     {
         let inner = Inner(downstream: subscriber, transform: catching(transform))
         upstream.receive(subscriber: inner)
+    }
+
+    public func map<Result>(
+        _ transform: @escaping (Output) -> Result
+    ) -> Publishers.Map<Upstream, Result> {
+        return .init(upstream: upstream) { transform(self.transform($0)) }
+    }
+
+    public func tryMap<Result>(
+        _ transform: @escaping (Output) throws -> Result
+    ) -> Publishers.TryMap<Upstream, Result> {
+        return .init(upstream: upstream) { try transform(self.transform($0)) }
     }
 }
 
 extension Publishers.TryMap {
 
-    public func receive<SubscriberType: Subscriber>(subscriber: SubscriberType)
-        where Output == SubscriberType.Input, SubscriberType.Failure == Error
+    public func receive<Downstream: Subscriber>(subscriber: Downstream)
+        where Output == Downstream.Input, Downstream.Failure == Error
     {
         let inner = Inner(downstream: subscriber, transform: catching(transform))
         upstream.receive(subscriber: inner)
+    }
+
+    public func map<Result>(
+        _ transform: @escaping (Output) -> Result
+    ) -> Publishers.TryMap<Upstream, Result> {
+        return .init(upstream: upstream) { try transform(self.transform($0)) }
+    }
+
+    public func tryMap<Result>(
+        _ transform: @escaping (Output) throws -> Result
+    ) -> Publishers.TryMap<Upstream, Result> {
+        return .init(upstream: upstream) { try transform(self.transform($0)) }
     }
 }
 


### PR DESCRIPTION
What's in this PR:

- tweaked the `Map` implementation a little — the tests were failing in compatibility mode (cc @MortyMerr)
- Implemented `TryMap` with tests. `TryMap` reuses most of the `Map`'s logic, so not many tests were needed.