### PR TITLE
FlatMap

### DIFF
--- a/RemainingCombineInterface.swift
+++ b/RemainingCombineInterface.swift
@@ -2735,51 +2735,6 @@ extension Publisher {
 
 extension Publishers {
 
-    public struct FlatMap<NewPublisher, Upstream> : Publisher where NewPublisher : Publisher, Upstream : Publisher, NewPublisher.Failure == Upstream.Failure {
-
-        /// The kind of values published by this publisher.
-        public typealias Output = NewPublisher.Output
-
-        /// The kind of errors this publisher might publish.
-        ///
-        /// Use `Never` if this `Publisher` does not publish errors.
-        public typealias Failure = Upstream.Failure
-
-        public let upstream: Upstream
-
-        public let maxPublishers: Subscribers.Demand
-
-        public let transform: (Upstream.Output) -> NewPublisher
-
-        public init(upstream: Upstream, maxPublishers: Subscribers.Demand, transform: @escaping (Upstream.Output) -> NewPublisher)
-
-        /// This function is called to attach the specified `Subscriber` to this `Publisher` by `subscribe(_:)`
-        ///
-        /// - SeeAlso: `subscribe(_:)`
-        /// - Parameters:
-        ///     - subscriber: The subscriber to attach to this `Publisher`.
-        ///                   once attached it can begin to receive values.
-        public func receive<S>(subscriber: S) where S : Subscriber, NewPublisher.Output == S.Input, Upstream.Failure == S.Failure
-    }
-}
-
-extension Publisher {
-
-    /// Transforms all elements from an upstream publisher into a new or existing publisher.
-    ///
-    /// `flatMap` merges the output from all returned publishers into a single stream of output.
-    ///
-    /// - Parameters:
-    ///   - maxPublishers: The maximum number of publishers produced by this method.
-    ///   - transform: A closure that takes an element as a parameter and returns a publisher
-    /// that produces elements of that type.
-    /// - Returns: A publisher that transforms elements from an upstream publisher into
-    /// a publisher of that element’s type.
-    public func flatMap<T, P>(maxPublishers: Subscribers.Demand = .unlimited, _ transform: @escaping (Self.Output) -> P) -> Publishers.FlatMap<P, Self> where T == P.Output, P : Publisher, Self.Failure == P.Failure
-}
-
-extension Publishers {
-
     /// A publisher that delays delivery of elements and completion to the downstream receiver.
     public struct Delay<Upstream, Context> : Publisher where Upstream : Publisher, Context : Scheduler {
 

--- a/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
@@ -1,0 +1,409 @@
+//
+//  Publishers.FlatMap.swift
+//
+//  Created by Eric Patey on 16.08.2019.
+//
+
+extension Publisher {
+
+    /// Transforms all elements from an upstream publisher into a new or existing
+    /// publisher.
+    ///
+    /// `flatMap` merges the output from all returned publishers into a single stream of
+    /// output.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: The maximum number of publishers produced by this method.
+    ///   - transform: A closure that takes an element as a parameter and returns a
+    ///   publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream publisher into
+    /// a publisher of that element’s type.
+    public func flatMap<Result, Child>(maxPublishers: Subscribers.Demand = .unlimited,
+                                       _ transform: @escaping (Self.Output) -> Child)
+        -> Publishers.FlatMap<Child, Self>
+        where Result == Child.Output, Child: Publisher, Self.Failure == Child.Failure {
+            return Publishers.FlatMap(upstream: self,
+                                      maxPublishers: maxPublishers,
+                                      transform: transform)
+    }
+}
+
+extension Publishers {
+    public struct FlatMap<Child, Upstream>: Publisher
+        where Child: Publisher, Upstream: Publisher, Child.Failure == Upstream.Failure {
+
+        /// The kind of values published by this publisher.
+        public typealias Output = Child.Output
+
+        /// The kind of errors this publisher might publish.
+        ///
+        /// Use `Never` if this `Publisher` does not publish errors.
+        public typealias Failure = Upstream.Failure
+
+        public let upstream: Upstream
+
+        public let maxPublishers: Subscribers.Demand
+
+        public let transform: (Upstream.Output) -> Child
+
+        public init(upstream: Upstream, maxPublishers: Subscribers.Demand,
+                    transform: @escaping (Upstream.Output) -> Child) {
+            self.upstream = upstream
+            self.maxPublishers = maxPublishers
+            self.transform = transform
+        }
+
+        /// This function is called to attach the specified `Subscriber` to this
+        /// `Publisher` by `subscribe(_:)`
+        ///
+        /// - SeeAlso: `subscribe(_:)`
+        /// - Parameters:
+        ///     - subscriber: The subscriber to attach to this `Publisher`.
+        ///                   once attached it can begin to receive values.
+        public func receive<Downstream>(subscriber: Downstream)
+            where Downstream: Subscriber,
+            Child.Output == Downstream.Input,
+            Upstream.Failure == Downstream.Failure {
+                let inner = Inner(downstream: subscriber,
+                                  maxPublishers: maxPublishers,
+                                  transform: transform)
+                upstream.subscribe(inner)
+        }
+    }
+}
+
+extension Publishers.FlatMap {
+    fileprivate final class Inner<Downstream: Subscriber>
+        : CustomStringConvertible,
+        Cancellable,
+        CustomReflectable
+    where Downstream.Input == Child.Output, Downstream.Failure == Upstream.Failure {
+        typealias Input = Upstream.Output
+        typealias Failure = Upstream.Failure
+
+        private typealias PendingValue = (
+            value: Downstream.Input,
+            // If the value was buffered at the time it became available, and the child's
+            // demand was left at `.none` we keep track of the child in `pausedChild` so
+            // that we can demand some more of it after sending this value.
+            pausedChild: ChildSubscriber?)
+
+        private let lock = Lock(recursive: false)
+        private let maxPublishers: Subscribers.Demand
+        private let transform: (Upstream.Output) -> Child
+        // Locking rules for this class.
+        //  - All mutable state must only be accessed while `lock` is held.
+        //  - In order to avoid any deadlock potential, it is absolutely forbidden to have
+        //      any sort of call out from this class while the lock is held. This is why
+        //      the draining of the work queue uses a relatively complex pattern.
+        private var downstream: Downstream?
+        private var childSubscribers = Set<ChildSubscriber>()
+        private var downstreamDemand = Subscribers.Demand.unlimited
+        private var valuesToSend = [PendingValue]()
+        private var queueIsBeingProcessed = false
+        private var sendFinishedAfterDrainingQueue = false
+        private var upstreamSubscription: Subscription?
+
+        var description: String { return "FlatMap" }
+
+        internal var customMirror: Mirror {
+            return Mirror(self, children: EmptyCollection())
+        }
+
+        init(downstream: Downstream,
+             maxPublishers: Subscribers.Demand,
+             transform: @escaping (Upstream.Output) -> Child) {
+            self.downstream = downstream
+            self.maxPublishers = maxPublishers
+            self.transform = transform
+        }
+
+        final func cancel() {
+            let (upstreamToCancel, childrenToCancel) = lock.do { ()
+                -> (Subscription?, Set<ChildSubscriber>) in
+                let upstreamToCancel = upstreamSubscription
+                upstreamSubscription = nil
+                return (upstreamToCancel, lockedDeactivateAndReturnChildToCancel())
+            }
+            upstreamToCancel?.cancel()
+            cancelChildren(childrenToCancel)
+        }
+    }
+}
+
+// Private implementation
+extension Publishers.FlatMap.Inner {
+    private func deactivate() {
+        cancelChildren(lock.do(lockedDeactivateAndReturnChildToCancel))
+    }
+
+    // Must be called with lock held.
+    private func lockedDeactivateAndReturnChildToCancel() -> Set<ChildSubscriber> {
+        downstream = nil
+        downstreamDemand = .none
+        let result = childSubscribers
+        childSubscribers.removeAll()
+        upstreamSubscription = nil
+        return result
+    }
+
+    private func cancelChildren(_ childrenToCancel: Set<ChildSubscriber>) {
+        childrenToCancel.forEach { $0.cancel() }
+    }
+
+    /// In a thread-safe way, this function performs the passed in work with the lock held
+    /// and then checks to see if either upstream or any of the child subscriptions remain
+    /// active. If there are no remaining active subscriptions, it enqueues the sending
+    /// of `.finished` downstream using the processing queue.
+    /// - Parameter lockedWork: block to be formed with the lock held.
+    private final func maybeSendFinishedAfterExecutingWork(lockedWork: () -> Void) {
+        let shouldProcessQueue: Bool = lock.do {
+            lockedWork()
+            if childSubscribers.isEmpty && upstreamSubscription == nil {
+                sendFinishedAfterDrainingQueue = true
+                if !queueIsBeingProcessed {
+                    queueIsBeingProcessed = true
+                    return true
+                }
+            }
+            return false
+        }
+
+        if shouldProcessQueue {
+            processQueue()
+        }
+    }
+
+    private func receivedCompletion(_ completion: Subscribers.Completion<Failure>,
+                                    fromChild child: ChildSubscriber) {
+        switch completion {
+        case .finished:
+            removeActiveSubscription(forChild: child)
+        case .failure:
+            downstream?.receive(completion: completion)
+            deactivate()
+        }
+    }
+
+    private func removeActiveSubscription(forChild child: ChildSubscriber) {
+        maybeSendFinishedAfterExecutingWork { childSubscribers.remove(child) }
+    }
+
+    private func receivedValue(_ value: Child.Output,
+                               fromChild child: ChildSubscriber) -> Subscribers.Demand {
+        // When receiving a value from a child, we need to determine what additional
+        // demand to return to the child. Apple's logic for this determination is as
+        // follows:
+        //  - If we are in `.unlimited` mode, we always request `.none` additional
+        //      else
+        //  - If there is a surplus relative to the demand, we request `.none`
+        //      else
+        //  - There is not yet a surplus, so request `.max(1)` more from the child
+
+        let (surplusAvailable, processTheQueue): (Bool, Bool) = lock.do {
+            // If we already have enough values to satisfy the demand, we "buffer" this
+            // child value establishing a surplus.
+            if downstreamDemand <= valuesToSend.count {
+                valuesToSend.append((value, child))
+                return (surplusAvailable: true, processTheQueue: false)
+            } else {
+                valuesToSend.append((value, nil))
+                if queueIsBeingProcessed {
+                    return (surplusAvailable: false, processTheQueue: false)
+                }
+                queueIsBeingProcessed = true
+                return (surplusAvailable: false, processTheQueue: true)
+            }
+        }
+
+        let demandResult = surplusAvailable || demandForChild() == .unlimited
+            ? Subscribers.Demand.none : Subscribers.Demand.max(1)
+
+        if processTheQueue {
+            processQueue()
+        }
+
+        return demandResult
+    }
+
+    private func demandForChild() -> Subscribers.Demand {
+        return self.downstreamDemand == .unlimited ? .unlimited : .max(1)
+    }
+
+    private enum QueueWorkStatus {
+        case noWork
+        case sendFinish
+        case sendValues(values: ArraySlice<PendingValue>)
+    }
+
+    private func processQueue() {
+        assert(queueIsBeingProcessed)
+
+        // We loop processing the queue in case somebody put stuff on the queue while we
+        // were sending values with the lock unlocked.
+        while true {
+            let work: QueueWorkStatus = lock.do {
+                if downstreamDemand == .none || valuesToSend.isEmpty {
+                    if sendFinishedAfterDrainingQueue && valuesToSend.isEmpty {
+                        return .sendFinish
+                    } else {
+                        queueIsBeingProcessed = false
+                        return .noWork
+                    }
+                }
+
+                let countToSend = min(valuesToSend.count, downstreamDemand.max ?? .max)
+                let result = valuesToSend[0..<countToSend]
+                // TODO: Consider an alternative storage to avoid O(n) removeFirst
+                valuesToSend.removeFirst(countToSend)
+                downstreamDemand -= countToSend
+                return .sendValues(values: result)
+            }
+
+            guard let downstream = downstream else { return }
+
+            switch work {
+            case .noWork:
+                return
+            case .sendFinish:
+                downstream.receive(completion: .finished)
+                deactivate()
+                return
+            case .sendValues(let values):
+                var newDemand = Subscribers.Demand.none
+                values.forEach {
+                    newDemand += downstream.receive($0.value)
+                    // pausedChild is present only if the value was buffered and the
+                    // child's demand was left at `.none`. In that case, once we send the
+                    // buffered value, we need to tell the child to get another value.
+                    $0.pausedChild?.request(.max(1))
+                }
+
+                if newDemand != .none {
+                    lock.do { downstreamDemand += newDemand }
+                }
+            }
+        }
+    }
+}
+
+// This `Subscriber` implementation is for `FlatMap`'s upstream subscription
+extension Publishers.FlatMap.Inner: Subscriber {
+    // FlatMap received the upstream subscription
+    fileprivate func receive(subscription: Subscription) {
+        upstreamSubscription = subscription
+        downstream?.receive(subscription: self)
+        subscription.request(maxPublishers)
+    }
+
+    /// Receive a new value from the upstream subscription. A new child subscription
+    /// will be made on the `Child` that the input value is transformed into.
+    /// - Parameter input: a value to be transformed by `transform`
+    fileprivate func receive(_ input: Input) -> Subscribers.Demand {
+        let newChildSubscriber = ChildSubscriber(parent: self)
+
+        lock.do { _ = childSubscribers.insert(newChildSubscriber) }
+
+        self.transform(input).subscribe(newChildSubscriber)
+
+        return .none
+    }
+
+    // Upstream subscription completed
+    fileprivate func receive(completion: Subscribers.Completion<Failure>) {
+        switch completion {
+        case .finished:
+            maybeSendFinishedAfterExecutingWork { upstreamSubscription = nil }
+        case .failure:
+            downstream?.receive(completion: completion)
+            deactivate()
+        }
+    }
+}
+
+// Inner is the `Subscription` for `Downstream`
+extension Publishers.FlatMap.Inner: Subscription {
+    fileprivate func request(_ demand: Subscribers.Demand) {
+        let (drainTheQueue, becameUnlimited) = lock.do { () -> (Bool, Bool) in
+            let becameUnlimited =
+                (demand == .unlimited) && (downstreamDemand != .unlimited)
+            downstreamDemand = demand
+            defer { queueIsBeingProcessed = true }
+            return (!queueIsBeingProcessed, becameUnlimited)
+        }
+
+        if becameUnlimited {
+            // TODO: This code isn't yet thread safe. The correct change is to do this
+            // through the queue just like sending values and finished. Finished is
+            // done through the queue as a bit of a hack. The right design is to have
+            // an enum of actions on the queue. That enum will include (send value,
+            // send finished, set child demand).
+            let newChildDemand = demandForChild()
+            childSubscribers.forEach { $0.request(newChildDemand) }
+        }
+
+        if drainTheQueue {
+            processQueue()
+        }
+    }
+}
+
+extension Publishers.FlatMap.Inner {
+    /// ChildSubscriber is needed to help implement the backpressure/demand strategy.
+    /// Specifically, a custom subscriber is needed to manage the demand of the child
+    /// subscription:
+    ///  - Send .max(1) request when the subscription is received
+    ///  - Send .max(1) request when downstream subscriber demands more and a previously
+    ///   buffered value from the child was sent. (When the value was buffered, the
+    ///   child's demand reached .none - effectively pausing the child.)
+    fileprivate final class ChildSubscriber: Hashable {
+        internal typealias Input = Downstream.Input
+        internal typealias Failure = Downstream.Failure
+
+        private var _upstreamSubscription: Subscription?
+        private unowned let _parent: Publishers.FlatMap<Child, Upstream>.Inner<Downstream>
+
+        init(parent: Publishers.FlatMap<Child, Upstream>.Inner<Downstream>) {
+            _parent = parent
+        }
+
+        fileprivate func request(_ demand: Subscribers.Demand) {
+            _upstreamSubscription?.request(demand)
+        }
+
+        public static func == (lhs: ChildSubscriber, rhs: ChildSubscriber) -> Bool {
+            return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(ObjectIdentifier(self))
+        }
+    }
+}
+
+extension Publishers.FlatMap.Inner.ChildSubscriber: Cancellable {
+    internal func cancel() {
+        _upstreamSubscription?.cancel()
+        _upstreamSubscription = nil
+    }
+}
+
+extension Publishers.FlatMap.Inner.ChildSubscriber: Subscriber {
+    internal func receive(subscription: Subscription) {
+        if _upstreamSubscription == nil {
+            _upstreamSubscription = subscription
+            subscription.request(_parent.demandForChild())
+        } else {
+            assertionFailure()
+            subscription.cancel()
+        }
+    }
+
+    fileprivate func receive(_ input: Input) -> Subscribers.Demand {
+        return _parent.receivedValue(input, fromChild: self)
+    }
+
+    fileprivate func receive(completion: Subscribers.Completion<Failure>) {
+        _parent.receivedCompletion(completion, fromChild: self)
+    }
+}

--- a/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
@@ -75,8 +75,7 @@ extension Publishers {
 extension Publishers.FlatMap {
     fileprivate final class Inner<Downstream: Subscriber>
         : CustomStringConvertible,
-        Cancellable,
-        CustomReflectable
+        Cancellable
     where Downstream.Input == Child.Output, Downstream.Failure == Upstream.Failure {
         typealias Input = Upstream.Output
         typealias Failure = Upstream.Failure
@@ -105,10 +104,6 @@ extension Publishers.FlatMap {
         private var upstreamSubscription: Subscription?
 
         var description: String { return "FlatMap" }
-
-        internal var customMirror: Mirror {
-            return Mirror(self, children: EmptyCollection())
-        }
 
         init(downstream: Downstream,
              maxPublishers: Subscribers.Demand,

--- a/Tests/OpenCombineTests/PublisherTests/FlatMapTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/FlatMapTests.swift
@@ -346,7 +346,8 @@ final class FlatMapTests: XCTestCase {
                     received777Sem.signal()
                 }
                 return .none
-        })
+            }
+        )
 
         flatMap.subscribe(downstreamSubscriber)
 

--- a/Tests/OpenCombineTests/PublisherTests/FlatMapTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/FlatMapTests.swift
@@ -1,0 +1,624 @@
+//
+//  FlatMapTests.swift
+//
+//  Created by Eric Patey on 17.08.2019.
+//
+
+import XCTest
+
+#if OPENCOMBINE_COMPATIBILITY_TEST
+import Combine
+#else
+import OpenCombine
+#endif
+
+/// Helper function for predictably testing concurrency/race scenarios.
+/// - Parameter block: block to execute concurrently
+///
+/// Apple, surprisingly, calls out to subscribers with a lock held. This will absolutely
+/// block children who send values concurrently until the current downstream value
+/// delivery has been completed.
+///
+/// This means that, without a timeout, the code below is guaranteed to deadlock. Because
+/// of this we need to choose a timeout that is low enough to not materially slow down the
+/// tests, but long enough to ensure that we are effectively testing the desired race
+/// conditions. It needs to be a long enough timeout to allow the caller's block to begin
+/// executing.
+///
+/// I understand that timeouts like this are a smell. I'd be happy to entertain other ways
+/// to deterministically test concurrency/race conditions.
+
+func performConcurrentBlock(_ block: @escaping () -> Void) {
+    let sem = DispatchSemaphore(value: 0)
+    DispatchQueue.global(qos: .background).async {
+        block()
+        sem.signal()
+    }
+    #if OPENCOMBINE_COMPATIBILITY_TEST
+    // If running in compatibility mode, assert that we got a timeout. If not, Apple
+    // changed their implementation to not call out with a lock held.
+    XCTAssertEqual(sem.wait(timeout: DispatchTime.now() + 0.01), .timedOut)
+    #else
+    sem.wait()
+    #endif
+}
+
+@available(macOS 10.15, iOS 13.0, *)
+final class FlatMapTests: XCTestCase {
+
+    static let allTests = [
+        ("testSendsChildValues", testSendsChildValues),
+        ("testChildSubscribeDeadlock", testChildSubscribeDeadlock),
+        ("testCancelCancels", testCancelCancels),
+        ("testUpstreamDemandWithMaxPublishers", testUpstreamDemandWithMaxPublishers),
+        ("testUpstreamDemandWithNoMaxPublishers", testUpstreamDemandWithNoMaxPublishers),
+        ("testChildDemandWhenUnlimited", testChildDemandWhenUnlimited),
+        ("testChildDemandWhenLimited", testChildDemandWhenLimited),
+        ("testDemandFromLimitedtoUnlimited", testDemandFromLimitedToUnlimited),
+        ("testChildValueReceivedWhileSendingValue",
+         testChildValueReceivedWhileSendingValue),
+        ("testCompletesProperlyWhenChildrenOutliveUpstream",
+         testCompletesProperlyWhenChildrenOutliveUpstream),
+        ("testCompletesProperlyWhenUpstreamOutlivesChildren",
+         testCompletesProperlyWhenUpstreamOutlivesChildren),
+        ("testDoesNotCompleteWithBufferedValues", testDoesNotCompleteWithBufferedValues),
+        ("testFailsIfUpstreamFails", testFailsIfUpstreamFails),
+        ("testFailsIfChildFails", testFailsIfChildFails),
+        ("testFailsWithoutSendingBufferedValues", testFailsWithoutSendingBufferedValues),
+        ("testAllSubscriptionsReleasedOnUpstreamFailure",
+         testAllSubscriptionsReleasedOnUpstreamFailure),
+        ("testAllSubscriptionsReleasedOnChildFailure",
+         testAllSubscriptionsReleasedOnChildFailure),
+        ("testSendsSubcriptionDownstreamBeforeDemandUpstream",
+         testSendsSubcriptionDownstreamBeforeDemandUpstream),
+        ("testTestSuiteIncludesAllTests", testTestSuiteIncludesAllTests)
+    ]
+
+    func testSendsChildValues() {
+        let upstreamPublisher = PassthroughSubject<
+            PassthroughSubject<Int, TestingError>,
+            TestingError>()
+        let childPublisher1 = PassthroughSubject<Int, TestingError>()
+        let childPublisher2 = PassthroughSubject<Int, TestingError>()
+
+        let flatMap = upstreamPublisher.flatMap { $0 }
+
+        let downstreamSubscriber = TrackingSubscriber(receiveSubscription: {
+            $0.request(.unlimited)
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(childPublisher1)
+        upstreamPublisher.send(childPublisher2)
+
+        childPublisher1.send(666)
+        childPublisher2.send(777)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777)])
+    }
+
+    // This test ensures that the code can properly re-enter when synchronously receiving
+    // a value during subscription (which Just(_) does).
+    //  1. FlatMap.Inner.receive(_ input:)
+    //    2. Publisher.subscribe
+    //      ...
+    //      3. FlatMap.Inner.ChildSubscriber.recive(subscription:)
+    //        4. subscription.request()
+    //          5. Just.Inner.request()
+    //            6. FlatMap.Inner.child(_:receivedValue)
+    //              7. lock
+    //
+    // At one point, I had a bug where the lock was taken by #1 before calling #2
+    // This broke the rules of calling out with a lock held, and lead to a deadlock
+    // at #7.
+    //
+    // Also, in my opinion, working around the issue with recursive locks is a smell.
+    func testChildSubscribeDeadlock() {
+        let upstreamSubscription = CustomSubscription()
+        let upstreamPublisher = CustomPublisherBase<Int, Never>(
+            subscription: upstreamSubscription)
+
+        let flatMap = upstreamPublisher.flatMap(maxPublishers: .max(2)) { Just($0) }
+
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+        XCTAssertEqual(upstreamPublisher.send(666), .none)
+
+        // Simply making it here shows that there's no dealock
+    }
+
+    func testCancelCancels() {
+        let upstreamSubscription = CustomSubscription()
+        let upstreamPublisher = CustomPublisherBase<Int, Never>(
+            subscription: upstreamSubscription)
+
+        let childSubscription = CustomSubscription()
+        let childPublisher = CustomPublisherBase<Int, Never>(
+            subscription: childSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { _ in childPublisher }
+
+        var downstreamSubscription: Subscription?
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(receiveSubscription:
+        {
+            downstreamSubscription = $0
+            $0.request(.unlimited)
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(upstreamPublisher.send(1), .none)
+
+        downstreamSubscription?.cancel()
+
+        XCTAssertEqual(upstreamSubscription.history.last, .cancelled)
+        XCTAssertEqual(childSubscription.history.last, .cancelled)
+    }
+
+    func testUpstreamDemandWithMaxPublishers() {
+        var upstreamDemand = Subscribers.Demand.none
+        let upstreamSubscription = CustomSubscription(onRequest: { upstreamDemand += $0 })
+        let upstreamPublisher = CustomPublisherBase<Int, Never>(
+            subscription: upstreamSubscription)
+
+        let flatMap = upstreamPublisher.flatMap(maxPublishers: .max(2)) { Just($0) }
+
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(upstreamDemand, .max(2))
+    }
+
+    func testUpstreamDemandWithNoMaxPublishers() {
+        var upstreamDemand = Subscribers.Demand.none
+        let upstreamSubscription = CustomSubscription(onRequest: { upstreamDemand += $0 })
+        let upstreamPublisher = CustomPublisherBase<Int, Never>(
+            subscription: upstreamSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { Just($0) }
+
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(upstreamDemand, .unlimited)
+    }
+
+    func testChildDemandWhenUnlimited() throws {
+        let upstreamPublisher = PassthroughSubject<Void, Never>()
+
+        var childDemand = Subscribers.Demand.none
+        let childSubscription = CustomSubscription(onRequest: { childDemand += $0 })
+        let childPublisher = CustomPublisherBase<Int, Never>(
+            subscription: childSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { _ in childPublisher }
+
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(receiveSubscription:
+        {
+            $0.request(.unlimited)
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send()
+
+        XCTAssertEqual(childDemand, .unlimited)
+
+        XCTAssertEqual(childPublisher.send(666), .none)
+    }
+
+    func testChildDemandWhenLimited() throws {
+        let upstreamPublisher = PassthroughSubject<AnyPublisher<Int, Never>, Never>()
+
+        var child1Demand = Subscribers.Demand.none
+        let child1Subscription = CustomSubscription(onRequest: { child1Demand += $0 })
+        let child1Publisher = CustomPublisherBase<Int, Never>(
+            subscription: child1Subscription)
+
+        var child2Demand = Subscribers.Demand.none
+        let child2Subscription = CustomSubscription(onRequest: { child2Demand += $0 })
+        let child2Publisher = CustomPublisherBase<Int, Never>(
+            subscription: child2Subscription)
+
+        let flatMap = upstreamPublisher.flatMap { $0 }
+
+        var downstreamSubscription: Subscription?
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(receiveSubscription:
+        {
+            downstreamSubscription = $0
+            $0.request(.max(2))
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(AnyPublisher(child1Publisher))
+        upstreamPublisher.send(AnyPublisher(child2Publisher))
+
+        // Apple starts out the children with a demand of 1. On receipt of a child value,
+        // 1 more is demanded until it has one extra/buffered value after the downstream
+        // demand is satisfied.
+        XCTAssertEqual(child1Demand, .max(1))
+        XCTAssertEqual(child2Demand, .max(1))
+
+        // Downstream demand is 2, so:
+        //  - this value gets sent
+        //  - downstream demand goes down to 1
+        //  - child is asked for 1 more
+        XCTAssertEqual(child1Publisher.send(666), .max(1))
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666)])
+
+        // Downstream demand is 1, so:
+        //  - this value gets sent
+        //  - downstream demand goes down to 0, but still need a buffered value
+        //  - child is asked for 1 more
+        XCTAssertEqual(child1Publisher.send(777), .max(1))
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777)])
+
+        // Downstream demand is 0, so:
+        //  - this value is buffered and NOT sent
+        //  - downstream demand is 0 and there's a buffered value
+        //  - child is asked for 0 more
+        XCTAssertEqual(child1Publisher.send(888), .none)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777)])
+
+        XCTAssertEqual(child1Publisher.send(999), .none)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777)])
+
+        // Downstream demands more, so:
+        //  - the buffered value gets sent
+        //  - child is asked for 1 more
+        XCTAssertEqual(child1Demand, .max(1))
+        XCTAssertEqual(child2Demand, .max(1))
+        try XCTUnwrap(downstreamSubscription).request(.max(10))
+        // This is a little odd, but rather than re-establishing a demand of 1 on the
+        // child like it did initially, Apple appears to demand 1 of the child for every
+        // buffered value that was sent. In this case, child1 is asked for 2 more.
+        XCTAssertEqual(child1Demand, .max(3))
+        XCTAssertEqual(child2Demand, .max(1))
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777),
+                                                      .value(888),
+                                                      .value(999)])
+    }
+
+    func testDemandFromLimitedToUnlimited() {
+        let upstreamPublisher = PassthroughSubject<Void, Never>()
+
+        var childDemand = Subscribers.Demand.none
+        let childSubscription = CustomSubscription(onRequest: { childDemand += $0 })
+        let childPublisher = CustomPublisherBase<Int, Never>(
+            subscription: childSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { _ in childPublisher }
+
+        var downstreamSubscription: Subscription?
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(receiveSubscription:
+        {
+            downstreamSubscription = $0
+            $0.request(.max(3))
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send()
+
+        XCTAssertEqual(childDemand, .max(1))
+
+        downstreamSubscription?.request(.unlimited)
+        XCTAssertEqual(childDemand, .unlimited)
+    }
+
+    func testChildValueReceivedWhileSendingValue() throws {
+        let upstreamPublisher = PassthroughSubject<AnyPublisher<Int, TestingError>,
+            TestingError>()
+
+        let child1Publisher = CustomPublisher(subscription: CustomSubscription())
+        let child2Publisher = CustomPublisher(subscription: CustomSubscription())
+
+        let flatMap = upstreamPublisher.flatMap { $0 }
+
+        let received777Sem = DispatchSemaphore(value: 0)
+
+        let downstreamSubscriber = TrackingSubscriber(
+            receiveSubscription: { $0.request(.max(2)) },
+            receiveValue: {
+                if $0 == 666 {
+                    performConcurrentBlock {
+                        XCTAssertEqual(child2Publisher.send(777), .max(1))
+                    }
+                } else if $0 == 777 {
+                    received777Sem.signal()
+                }
+                return .none
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(AnyPublisher(child1Publisher))
+        upstreamPublisher.send(AnyPublisher(child2Publisher))
+
+        XCTAssertEqual(child1Publisher.send(666), .max(1))
+        received777Sem.wait()
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777)])
+    }
+
+    func testCompletesProperlyWhenUpstreamOutlivesChildren() {
+        let upstreamPublisher = PassthroughSubject<AnyPublisher<Int, Never>, Never>()
+        let child1 = PassthroughSubject<Int, Never>()
+        let child2 = PassthroughSubject<Int, Never>()
+        let flatMap = upstreamPublisher.flatMap { $0 }
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(AnyPublisher(child1))
+        upstreamPublisher.send(AnyPublisher(child2))
+
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap")])
+
+        child1.send(666)
+        child1.send(completion: .finished)
+
+        // Better stay alive even after upstream and one child finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .value(666)])
+
+        child2.send(777)
+        child2.send(completion: .finished)
+
+        // Better stay alive even after all children finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .value(666),
+                                          .value(777)])
+
+        upstreamPublisher.send(completion: .finished)
+
+        // Better complete when upstream and all children finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .value(666),
+                                          .value(777),
+                                          .completion(.finished)])
+    }
+
+    func testCompletesProperlyWhenChildrenOutliveUpstream() {
+        let upstreamPublisher = PassthroughSubject<AnyPublisher<Int, Never>, Never>()
+        let child1 = PassthroughSubject<Int, Never>()
+        let child2 = PassthroughSubject<Int, Never>()
+        let flatMap = upstreamPublisher.flatMap { $0 }
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(AnyPublisher(child1))
+        upstreamPublisher.send(AnyPublisher(child2))
+
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap")])
+
+        upstreamPublisher.send(completion: .finished)
+
+        // Better stay alive even after upstream finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap")])
+
+        child1.send(666)
+        child1.send(completion: .finished)
+
+        // Better stay alive even after upstream and one child finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .value(666)])
+
+        child2.send(777)
+        child2.send(completion: .finished)
+
+        // Better complete when upstream and all children finished
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .value(666),
+                                          .value(777),
+                                          .completion(.finished)])
+    }
+
+    func testDoesNotCompleteWithBufferedValues() {
+        let upstreamPublisher = PassthroughSubject<Void, Never>()
+
+        let childSubscription = CustomSubscription()
+        let childPublisher = CustomPublisherBase<Int, Never>(
+            subscription: childSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { _ in childPublisher }
+
+        var downstreamSubscription: Subscription?
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(receiveSubscription:
+        {
+            downstreamSubscription = $0
+            $0.request(.max(1))
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send()
+
+        XCTAssertEqual(childPublisher.send(666), .max(1))
+        XCTAssertEqual(childPublisher.send(777), .none)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666)])
+
+        upstreamPublisher.send(completion: .finished)
+        childPublisher.send(completion: .finished)
+
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666)])
+
+        downstreamSubscription?.request(.unlimited)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .value(777),
+                                                      .completion(.finished)])
+    }
+
+    func testFailsIfUpstreamFails() {
+        let upstreamPublisher = PassthroughSubject<
+            AnyPublisher<Int, TestingError>,
+            TestingError>()
+        let flatMap = upstreamPublisher.flatMap { $0 }
+        let downstreamSubscriber = TrackingSubscriberBase<Int, TestingError>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                          .completion(.failure(TestingError.oops))])
+    }
+
+    func testFailsIfChildFails() {
+        let upstream = PassthroughSubject<AnyPublisher<Int, TestingError>, TestingError>()
+        let child = PassthroughSubject<Int, TestingError>()
+        let flatMap = upstream.flatMap { $0 }
+        let tracking = TrackingSubscriberBase<Int, TestingError>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        flatMap.subscribe(tracking)
+        upstream.send(AnyPublisher(child))
+
+        child.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(tracking.history, [.subscription("FlatMap"),
+                                          .completion(.failure(TestingError.oops))])
+    }
+
+    func testFailsWithoutSendingBufferedValues() {
+        let upstreamPublisher = PassthroughSubject<
+            PassthroughSubject<Int, TestingError>,
+            TestingError>()
+        let childPublisher = PassthroughSubject<Int, TestingError>()
+
+        let flatMap = upstreamPublisher.flatMap { $0 }
+
+        let downstreamSubscriber = TrackingSubscriber(receiveSubscription: {
+            $0.request(.max(1))
+        })
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        upstreamPublisher.send(childPublisher)
+
+        // Send a value
+        childPublisher.send(666)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666)])
+
+        // Buffer a value
+        childPublisher.send(777)
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666)])
+
+        // Fail
+        let error = TestingError.oops
+        upstreamPublisher.send(completion: .failure(error))
+        XCTAssertEqual(downstreamSubscriber.history, [.subscription("FlatMap"),
+                                                      .value(666),
+                                                      .completion(.failure(error))])
+    }
+
+    func testAllSubscriptionsReleasedOnUpstreamFailure() {
+        let upstreamSubscription = CustomSubscription()
+        let upstreamPublisher = CustomPublisherBase<Int, TestingError>(
+            subscription: upstreamSubscription)
+        let downstreamSubscriber = TrackingSubscriberBase<Int, TestingError>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        let childSubscription = CustomSubscription()
+        let child = CustomPublisher(subscription: childSubscription)
+
+        let flatMap = upstreamPublisher.flatMap { _ in child }
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(upstreamPublisher.send(1), .none)
+        XCTAssertEqual(child.send(666), .none)
+        upstreamPublisher.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(childSubscription.history, [.requested(.unlimited),
+                                                   .cancelled])
+        XCTAssertEqual(upstreamSubscription.history, [.requested(.unlimited)])
+    }
+
+    func testAllSubscriptionsReleasedOnChildFailure() {
+        let upstreamSubscription = CustomSubscription()
+        let upstreamPublisher = CustomPublisherBase<Int, TestingError>(
+            subscription: upstreamSubscription)
+        let downstreamSubscriber = TrackingSubscriberBase<Int, TestingError>(
+            receiveSubscription: { $0.request(.unlimited) })
+
+        let child1 = PassthroughSubject<Int, TestingError>()
+        let child2Subscription = CustomSubscription()
+        let child2 = CustomPublisher(subscription: child2Subscription)
+
+        let children = [AnyPublisher(child1), AnyPublisher(child2)]
+        let flatMap = upstreamPublisher.flatMap { children[$0] }
+
+        flatMap.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(upstreamPublisher.send(0), .none)
+        XCTAssertEqual(upstreamPublisher.send(1), .none)
+        child1.send(666)
+        XCTAssertEqual(child2.send(777), .none)
+        child1.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(child2Subscription.history, [.requested(.unlimited),
+                                                    .cancelled])
+        XCTAssertEqual(upstreamSubscription.history, [.requested(.unlimited)])
+    }
+
+    func testSendsSubcriptionDownstreamBeforeDemandUpstream() {
+        let sentDemandRequestUpstream = "Sent demand request upstream"
+        let sentSubscriptionDownstream = "Sent subcription downstream"
+        var receiveOrder: [String] = []
+
+        let upstreamSubscription = CustomSubscription(onRequest: { _ in
+            receiveOrder.append(sentDemandRequestUpstream) })
+        let upstreamPublisher = CustomPublisherBase<Int, Never>(
+            subscription: upstreamSubscription)
+        let flatMapPublisher = upstreamPublisher.flatMap { Just($0) }
+        let downstreamSubscriber = TrackingSubscriberBase<Int, Never>(
+            receiveSubscription: { _ in receiveOrder.append(sentSubscriptionDownstream) })
+
+        flatMapPublisher.subscribe(downstreamSubscriber)
+
+        XCTAssertEqual(receiveOrder, [sentSubscriptionDownstream,
+                                      sentDemandRequestUpstream])
+    }
+
+    // MARK: -
+    func testTestSuiteIncludesAllTests() {
+        // https://oleb.net/blog/2017/03/keeping-xctest-in-sync/
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let thisClass = type(of: self)
+        let allTestsCount = thisClass.allTests.count
+        let darwinCount = thisClass.defaultTestSuite.testCaseCount
+        XCTAssertEqual(allTestsCount,
+                       darwinCount,
+                       "\(darwinCount - allTestsCount) tests are missing from allTests")
+        #endif
+    }
+}


### PR DESCRIPTION
I'm taking a stab at `FlatMap`. In support of operators that need serialization of sending values from multiple upstream/child subscriptions, I've implemented a simple/fast `SerializedWorkQueue` that adheres to the `Combine` threading rules and avoids unnecessary context switches.

Remaining work:
- [x] Clean up and ensure all completion/failures paths are correct.
  - [x] Clean up and complete with `.failed` if either upstream or any children fail.
  - [x] Complete with `.finished` only after upstream and all children have completed (i.e. add refcounting of active subscriptions) AND all buffer values have been sent.
- [x] Figure out and add support for `maxPublishers`
- [x] Figure out non-trivial handling of demand for child subscriptions and implement it.
  - [x] Basic child demand scenarios work
  - [x] Add support for downstream demand going from `.unlimited` to `.max(x)`
  - [x] Add support for downstream demand going from `.max(x)` to `.unlimited`
- [x] Add unit tests 
- [x] Factor out common base class from `Inner` class to be shared with all _merge_ like operators.