### PR TITLE
Audit Publishers.Multicast for thread safety

### DIFF
--- a/Tests/OpenCombineTests/PublisherTests/MakeConnectableTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/MakeConnectableTests.swift
@@ -36,4 +36,10 @@ final class MakeConnectableTests: XCTestCase {
             $0.makeConnectable()
         }
     }
+
+    func testReflection() throws {
+        try MulticastTests.testGenericMulticastReflection {
+            $0.makeConnectable()
+        }
+    }
 }


### PR DESCRIPTION
Also, fix the semantics of `Inner`.