### PR TITLE
Fix lifetime behaviors of PassthroughSubject

### DIFF
--- a/Sources/OpenCombine/PassthroughSubject.swift
+++ b/Sources/OpenCombine/PassthroughSubject.swift
@@ -15,8 +15,7 @@ public final class PassthroughSubject<Output, Failure: Error>: Subject  {
 
     private var _completion: Subscribers.Completion<Failure>?
 
-    // TODO: Combine uses bag data structure
-    private var _subscriptions: [Conduit] = []
+    private var _subscriptions = Set<Conduit>()
 
     internal var upstreamSubscriptions: [Subscription] = []
 
@@ -52,7 +51,7 @@ public final class PassthroughSubject<Output, Failure: Error>: Subject  {
                 let subscription = Conduit(parent: self,
                                            downstream: AnySubscriber(subscriber))
 
-                _subscriptions.append(subscription)
+                _subscriptions.insert(subscription)
                 subscriber.receive(subscription: subscription)
             }
         }
@@ -92,7 +91,14 @@ public final class PassthroughSubject<Output, Failure: Error>: Subject  {
 
 extension PassthroughSubject {
 
-    fileprivate final class Conduit: Subscription {
+    fileprivate final class Conduit: Subscription, Hashable {
+        public static func == (lhs: Conduit, rhs: Conduit) -> Bool {
+            return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(ObjectIdentifier(self))
+        }
 
         fileprivate var _parent: PassthroughSubject?
 
@@ -112,8 +118,9 @@ extension PassthroughSubject {
 
         fileprivate func _receive(completion: Subscribers.Completion<Failure>) {
             if !_isCompleted {
-                _parent = nil
-                _downstream?.receive(completion: completion)
+                let downstream = _downstream
+                terminate()
+                downstream?.receive(completion: completion)
             }
         }
 
@@ -126,7 +133,13 @@ extension PassthroughSubject {
         }
 
         fileprivate func cancel() {
+            terminate()
+        }
+
+        private func terminate() {
+            _ = _parent?._lock.do { _parent?._subscriptions.remove(self) }
             _parent = nil
+            _downstream = nil
         }
     }
 }

--- a/Tests/OpenCombineTests/PassthroughSubjectTests.swift
+++ b/Tests/OpenCombineTests/PassthroughSubjectTests.swift
@@ -47,11 +47,12 @@ final class PassthroughSubjectTests: XCTestCase {
                 case .finished: subject.send(completion: .finished)
                 case .failed: subject.send(completion: .failure(.oops))
                 }
-                if weakSubscriber != nil { XCTFail("Subscriber leaked when reason is \(reason)") }
-                if weakSubscription != nil { XCTFail("Subscription leaked when reason is \(reason)") }
+
+                XCTAssertNil(weakSubscriber, "Subscriber leaked - \(reason)")
+                XCTAssertNil(weakSubscription, "Subscription leaked - \(reason)")
             }
 
-            if weakSubject != nil { XCTFail("Subject leaked when reason is \(reason)") }
+            XCTAssertNil(weakSubject, "Subject leaked -  \(reason)")
         }
     }
 

--- a/Tests/OpenCombineTests/PassthroughSubjectTests.swift
+++ b/Tests/OpenCombineTests/PassthroughSubjectTests.swift
@@ -43,9 +43,12 @@ final class PassthroughSubjectTests: XCTestCase {
                 }
 
                 switch reason {
-                case .cancelled: (weakSubscription as? Subscription)?.cancel()
-                case .finished: subject.send(completion: .finished)
-                case .failed: subject.send(completion: .failure(.oops))
+                case .cancelled:
+                    (weakSubscription as? Subscription)?.cancel()
+                case .finished:
+                    subject.send(completion: .finished)
+                case .failed:
+                    subject.send(completion: .failure(.oops))
                 }
 
                 XCTAssertNil(weakSubscriber, "Subscriber leaked - \(reason)")


### PR DESCRIPTION
While trying to reason about some other code by testing it out with a PassthroughSubject, I realized that the subject appeared to not behaving as expected after reaching a terminal state through any means - i.e. cancelled, finished or failed.

The Apple code properly releases references to everything (the publisher, subscription and subscriber) after the subscription becomes terminal.

My fear is that we have this flaw in many of our publisher implementations. I haven't had time to look yet.

While I was in there, I took care of the todo to use a bag/set collection rather than an array.