### PR TITLE
CocoaPods support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,22 @@ jobs:
           name: Run danger-swift
           command: danger-swift ci
 
+  "Run Pod spec lint":
+    macos:
+      xcode: "11.2.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+    steps:
+      - checkout
+      - run: 
+          name: Install Cocoapods
+          command: |
+            brew install cocoapods
+      - run:
+          name: Pod lib lint
+          command: |
+            pod lib lint --allow-warnings
+
 workflows:
   version: 2
   "OpenCombine: execute tests on macOS":
@@ -233,3 +249,6 @@ workflows:
   "OpenCombine: run SwiftLint and Danger":
     jobs:
       - "Run SwiftLint and Danger"
+  "OpenCombine: validate podspec files":
+    jobs:
+      - "Run Pod spec lint"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,9 +228,13 @@ jobs:
           command: |
             brew install cocoapods
       - run:
+          name: Update Pod repo
+          command: |
+            pod repo update --silent
+      - run:
           name: Pod lib lint
           command: |
-            pod lib lint --allow-warnings
+            pod lib lint --allow-warnings --verbose
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,10 +224,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update Pod repo
-          command: |
-            pod repo update --silent
-      - run:
           name: Pod lib lint
           command: |
             pod lib lint --allow-warnings --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,10 +223,6 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: "1"
     steps:
       - checkout
-      - run: 
-          name: Install Cocoapods
-          command: |
-            brew install cocoapods
       - run:
           name: Update Pod repo
           command: |

--- a/COpenCombineHelpers.podspec
+++ b/COpenCombineHelpers.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |spec|
+  spec.name          = "COpenCombineHelpers"
+  spec.version       = "0.5.0"
+  spec.summary       = "C++ Helpers for OpenCombine"
+
+  spec.description   = <<-DESC
+  C++ helpers necessary for the implementation of OpenCombine
+  DESC
+
+  spec.homepage      = "https://github.com/broadwaylamb/OpenCombine/"
+  spec.license       = "MIT"
+
+  spec.authors       = { "Sergej Jaskiewicz" => "jaskiewiczs@icloud.com" }
+  spec.source        = { :git => "https://github.com/broadwaylamb/OpenCombine.git", :tag => "#{spec.version}" }
+
+  spec.osx.deployment_target     = "10.10"
+  spec.ios.deployment_target     = "8.0"
+  spec.watchos.deployment_target = "2.0"
+  spec.tvos.deployment_target    = "9.0"
+
+  spec.header_mappings_dir       = "Sources/COpenCombineHelpers/include"
+  spec.source_files              = "Sources/COpenCombineHelpers/**/*.{cpp,h}"
+  spec.libraries                 = "c++"
+  
+  spec.pod_target_xcconfig = {
+    "DEFINES_MODULE" => "YES"
+  }
+end

--- a/OpenCombine.podspec
+++ b/OpenCombine.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+  spec.name          = "OpenCombine"
+  spec.version       = "0.5.0"
+  spec.summary       = "Open source implementation of Apple's Combine framework for processing values over time."
+
+  spec.description   = <<-DESC
+  An open source implementation of Apple's Combine framework for processing values over time.
+  DESC
+
+  spec.homepage      = "https://github.com/broadwaylamb/OpenCombine/"
+  spec.license       = "MIT"
+
+  spec.authors       = { "Sergej Jaskiewicz" => "jaskiewiczs@icloud.com" }
+  spec.source        = { :git => "https://github.com/broadwaylamb/OpenCombine.git", :tag => "#{spec.version}" }
+
+  spec.swift_version = "5.0"
+
+  spec.osx.deployment_target     = "10.10"
+  spec.ios.deployment_target     = "8.0"
+  spec.watchos.deployment_target = "2.0"
+  spec.tvos.deployment_target    = "9.0"
+
+  spec.source_files = "Sources/OpenCombine/**/*.swift"
+  spec.dependency     "COpenCombineHelpers"
+end

--- a/OpenCombineDispatch.podspec
+++ b/OpenCombineDispatch.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+  spec.name          = "OpenCombineDispatch"
+  spec.version       = "0.5.0"
+  spec.summary       = "OpenCombine Dispatching"
+
+  spec.description   = <<-DESC
+  Extends `DispatchQueue` with new methods and nested types.
+  DESC
+
+  spec.homepage      = "https://github.com/broadwaylamb/OpenCombine/"
+  spec.license       = "MIT"
+
+  spec.authors       = { "Sergej Jaskiewicz" => "jaskiewiczs@icloud.com" }
+  spec.source        = { :git => "https://github.com/broadwaylamb/OpenCombine.git", :tag => "#{spec.version}" }
+
+  spec.swift_version = "5.0"
+
+  spec.osx.deployment_target     = "10.10"
+  spec.ios.deployment_target     = "8.0"
+  spec.watchos.deployment_target = "2.0"
+  spec.tvos.deployment_target    = "9.0"
+
+  spec.source_files = "Sources/OpenCombineDispatch/**/*.swift"
+  spec.dependency     "OpenCombine"
+end

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project is in early development.
 ### Installation
 `OpenCombine` contains two public targets: `OpenCombine` and `OpenCombineDispatch` (the third one, `COpenCombineHelpers`, is considered private. Don't import it in your projects).
 
-OpenCombine itself does not have any dependencies. Not even platform libraries like Foundation or Dispatch. If you want to use OpenCombine with Dispatch (for example for using `DispatchQueue` as `Scheduler` for operators like `debounce`, `receive(on:)` etc.), you will need to import both `OpenCombine` and `OpenCombineDispatch`.
+OpenCombine itself does not have any dependencies. Not even Foundation or Dispatch. If you want to use OpenCombine with Dispatch (for example for using `DispatchQueue` as `Scheduler` for operators like `debounce`, `receive(on:)` etc.), you will need to import both `OpenCombine` and `OpenCombineDispatch`.
 
 ##### Swift Package Manager
 ###### Swift Package
@@ -32,7 +32,7 @@ targets: [
 ###### Xcode
 `OpenCombine` can also be added as a SPM dependency directly in your Xcode project *(requires Xcode 11 upwards)*.
 
-To do so, open XCode, use **File** → **Swift Packages** → **Add Package Dependency…**, enter the [repository URL](https://github.com/broadwaylamb/OpenCombine.git), choose the latest available version, and activate the checkboxes:
+To do so, open Xcode, use **File** → **Swift Packages** → **Add Package Dependency…**, enter the [repository URL](https://github.com/broadwaylamb/OpenCombine.git), choose the latest available version, and activate the checkboxes:
 
 <p align="center">
 <img alt="Select the OpenCombine and OpenCombineDispatch targets" 
@@ -40,7 +40,7 @@ To do so, open XCode, use **File** → **Swift Packages** → **Add Package Depe
 </p>
 
 ##### CocoaPods
-To add `OpenCombine` to a project using [CocoaPods](https://cocoapods.org/), add `OpenCombine` and `OpenCombineDispatch` to the list of target dependencies in your `Podfile` file. 
+To add `OpenCombine` to a project using [CocoaPods](https://cocoapods.org/), add `OpenCombine` and `OpenCombineDispatch` to the list of target dependencies in your `Podfile`. 
 
 ```ruby
 pod 'OpenCombine', '~> 0.5.0'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ The main goal of this project is to provide a compatible, reliable and efficient
 
 The project is in early development.
 
+### Installation
+`OpenCombine` contains of two targets: `OpenCombine` and `OpenCombineDispatch`.
+
+##### Swift Package Manager
+To add `OpenCombine` to your [SPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file.
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/broadwaylamb/OpenCombine.git", from: "0.5.0")
+],
+targets: [
+    .target(name: "Package", dependencies: ["OpenCombine", "OpenCombineDispatch"])
+]
+```
+
+##### CocoaPods
+To add `OpenCombine` to a project using [CocoaPods](https://cocoapods.org/), add `OpenCombine` and `OpenCombineDispatch` to the list of target dependencies in your `Podfile` file. 
+
+```ruby
+pod 'OpenCombine', '~> 0.5.0'
+pod 'OpenCombineDispatch', '~> 0.5.0'
+```
+
 ### Contributing
 
 In order to work on this project you will need Xcode 10.2 and Swift 5.0 or later.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ The main goal of this project is to provide a compatible, reliable and efficient
 The project is in early development.
 
 ### Installation
-`OpenCombine` contains of two targets: `OpenCombine` and `OpenCombineDispatch`.
+`OpenCombine` contains two public targets: `OpenCombine` and `OpenCombineDispatch` (the third one, `COpenCombineHelpers`, is considered private. Don't import it in your projects).
+
+OpenCombine itself does not have any dependencies. Not even platform libraries like Foundation or Dispatch. If you want to use OpenCombine with Dispatch (for example for using `DispatchQueue` as `Scheduler` for operators like `debounce`, `receive(on:)` etc.), you will need to import both `OpenCombine` and `OpenCombineDispatch`.
 
 ##### Swift Package Manager
+###### Swift Package
 To add `OpenCombine` to your [SPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file.
 
 ```swift
@@ -22,9 +25,19 @@ dependencies: [
     .package(url: "https://github.com/broadwaylamb/OpenCombine.git", from: "0.5.0")
 ],
 targets: [
-    .target(name: "Package", dependencies: ["OpenCombine", "OpenCombineDispatch"])
+    .target(name: "MyAwesomePackage", dependencies: ["OpenCombine", "OpenCombineDispatch"])
 ]
 ```
+
+###### Xcode
+`OpenCombine` can also be added as a SPM dependency directly in your Xcode project *(requires Xcode 11 upwards)*.
+
+To do so, open XCode, use **File** → **Swift Packages** → **Add Package Dependency…**, enter the [repository URL](https://github.com/broadwaylamb/OpenCombine.git), choose the latest available version, and activate the checkboxes:
+
+<p align="center">
+<img alt="Select the OpenCombine and OpenCombineDispatch targets" 
+	src="https://user-images.githubusercontent.com/16309982/67618468-bd379f80-f7f8-11e9-917f-e76e878a1aee.png" width="70%">
+</p>
 
 ##### CocoaPods
 To add `OpenCombine` to a project using [CocoaPods](https://cocoapods.org/), add `OpenCombine` and `OpenCombineDispatch` to the list of target dependencies in your `Podfile` file. 


### PR DESCRIPTION
Adding support for CocoaPods. This required to add three separate podspecs, one for the C++ helpers, one for OpenCombine and one for OpenCombineDispatch. Created a local example project and tested that it build with both dynamic frameworks and static libraries. ✅ 

As `os_unfair_lock` is only available on versions above the minimum deployment target, warnings are produced. There is a check in place that they're actually not used when they're not available. Therefore passing `--allow-warnings` to `pod lib lint` should be fine.

This PR does not expose the tests via a test_spec as this would've required adding a podspec to `GottaGoFast`. As this dependency was recently dropped, let's tackle this in a future PR. 

Fixes #48