### PR TITLE
If Multicast receives subscription twice, cancel the second one

### DIFF
--- a/Sources/OpenCombine/Publishers/Publishers.Multicast.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Multicast.swift
@@ -159,6 +159,7 @@ extension Publishers.Multicast {
             lock.lock()
             guard case let .ready(upstream, downstream) = state else {
                 lock.unlock()
+                subscription.cancel()
                 return
             }
             state = .subscribed(upstream: upstream,

--- a/Tests/OpenCombineTests/Helpers/TrackingSubscriber.swift
+++ b/Tests/OpenCombineTests/Helpers/TrackingSubscriber.swift
@@ -282,10 +282,10 @@ final class TrackingSubjectBase<Output: Equatable, Failure: Error>
 
     private let _passthrough = PassthroughSubject<Output, Failure>()
     private(set) var history: [Event] = []
-    private let _receiveSubscriber: ((CustomCombineIdentifierConvertible) -> Void)?
+    private let _receiveSubscriber: ((AnySubscriber<Output, Failure>) -> Void)?
     private let _onDeinit: (() -> Void)?
 
-    init(receiveSubscriber: ((CustomCombineIdentifierConvertible) -> Void)? = nil,
+    init(receiveSubscriber: ((AnySubscriber<Output, Failure>) -> Void)? = nil,
          onDeinit: (() -> Void)? = nil) {
         _receiveSubscriber = receiveSubscriber
         _onDeinit = onDeinit
@@ -313,7 +313,7 @@ final class TrackingSubjectBase<Output: Equatable, Failure: Error>
     func receive<Downstream: Subscriber>(subscriber: Downstream)
         where Failure == Downstream.Failure, Output == Downstream.Input
     {
-        _receiveSubscriber?(subscriber)
+        _receiveSubscriber?(AnySubscriber(subscriber))
         history.append(.subscriber)
         _passthrough.subscribe(subscriber)
     }

--- a/Tests/OpenCombineTests/PublisherTests/MulticastTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/MulticastTests.swift
@@ -308,6 +308,19 @@ final class MulticastTests: XCTestCase {
         XCTAssertEqual(counter, 1, "The createSubject closure should be called once")
     }
 
+    func testMulticastReceiveSubscriptionTwice() {
+        let publisher = CustomPublisher(subscription: CustomSubscription())
+        var inner: AnySubscriber<Int, TestingError>?
+        let trackingSubject = TrackingSubject<Int>(receiveSubscriber: { inner = $0 })
+        let multicast = publisher.multicast(subject: trackingSubject)
+        let tracking = TrackingSubscriber()
+        multicast.subscribe(tracking)
+        XCTAssertNotNil(inner)
+        let extraSubscription = CustomSubscription()
+        inner?.receive(subscription: extraSubscription)
+        XCTAssertEqual(extraSubscription.history, [.cancelled])
+    }
+
     func testMulticastReceiveValueBeforeSubscription() {
         testReceiveValueBeforeSubscription(
             value: 0,


### PR DESCRIPTION
This PR also marks the milestone of 900 tests in our test suite, which is awesome, but still not enough!