### PR TITLE
Implement Publishers.ReplaceEmpty

### DIFF
--- a/RemainingCombineInterface.swift
+++ b/RemainingCombineInterface.swift
@@ -842,47 +842,6 @@ extension Publisher {
 
 extension Publishers {
 
-    /// A publisher that replaces an empty stream with a provided element.
-    public struct ReplaceEmpty<Upstream> : Publisher where Upstream : Publisher {
-
-        /// The kind of values published by this publisher.
-        public typealias Output = Upstream.Output
-
-        /// The kind of errors this publisher might publish.
-        ///
-        /// Use `Never` if this `Publisher` does not publish errors.
-        public typealias Failure = Upstream.Failure
-
-        /// The element to deliver when the upstream publisher finishes without delivering any elements.
-        public let output: Upstream.Output
-
-        /// The publisher from which this publisher receives elements.
-        public let upstream: Upstream
-
-        public init(upstream: Upstream, output: Publishers.ReplaceEmpty<Upstream>.Output)
-
-        /// This function is called to attach the specified `Subscriber` to this `Publisher` by `subscribe(_:)`
-        ///
-        /// - SeeAlso: `subscribe(_:)`
-        /// - Parameters:
-        ///     - subscriber: The subscriber to attach to this `Publisher`.
-        ///                   once attached it can begin to receive values.
-        public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, Upstream.Output == S.Input
-    }
-}
-
-extension Publisher {
-
-    /// Replaces an empty stream with the provided element.
-    ///
-    /// If the upstream publisher finishes without producing any elements, this publisher emits the provided element, then finishes normally.
-    /// - Parameter output: An element to emit when the upstream publisher finishes without emitting any elements.
-    /// - Returns: A publisher that replaces an empty stream with the provided output element.
-    public func replaceEmpty(with output: Self.Output) -> Publishers.ReplaceEmpty<Self>
-}
-
-extension Publishers {
-
     /// A publisher that raises a fatal error upon receiving any failure, and otherwise republishes all received input.
     ///
     /// Use this function for internal sanity checks that are active during testing but do not impact performance of shipping code.

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
@@ -151,6 +151,12 @@ extension Publishers.ReplaceEmpty {
             demand.assertNonZero()
             lock.lock()
             downstreamRequested = true
+            if finishedWithoutUpstream {
+                lock.unlock()
+                _ = downstream.receive(output)
+                downstream.receive(completion: .finished)
+                return
+            }
             guard case let .subscribed(subscription) = status else {
                 lock.unlock()
                 return

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
@@ -134,7 +134,10 @@ extension Publishers.ReplaceEmpty {
             lock.unlock()
             switch completion {
             case .finished:
-                guard downstreamRequested else { return }
+                guard downstreamRequested else {
+                    finishedWithoutUpstream = true
+                    return
+                }
                 if receivedUpstream {
                     _ = downstream.receive(output)
                 }

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
@@ -27,7 +27,7 @@ extension Publisher {
 extension Publishers {
 
     /// A publisher that replaces an empty stream with a provided element.
-    public struct ReplaceEmpty<Upstream>: Publisher where Upstream: Publisher {
+    public struct ReplaceEmpty<Upstream: Publisher>: Publisher {
 
         /// The kind of values published by this publisher.
         public typealias Output = Upstream.Output
@@ -118,11 +118,7 @@ extension Publishers.ReplaceEmpty {
             }
             isEmpty = false
             lock.unlock()
-            let demand = downstream.receive(input)
-            guard demand > 0 else {
-                return .none
-            }
-            return demand
+            return downstream.receive(input)
         }
 
         func receive(completion: Subscribers.Completion<Upstream.Failure>) {

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
@@ -84,7 +84,7 @@ extension Publishers.ReplaceEmpty {
         private let output: Output
         private let downstream: Downstream
 
-        private var receivedUpstream = true
+        private var receivedUpstream = false
         private var lock = UnfairLock.allocate()
         private var downstreamRequested = false
         private var finishedWithoutUpstream = false
@@ -119,7 +119,7 @@ extension Publishers.ReplaceEmpty {
                 lock.unlock()
                 return .none
             }
-            receivedUpstream = false
+            receivedUpstream = true
             lock.unlock()
             return downstream.receive(input)
         }
@@ -138,7 +138,7 @@ extension Publishers.ReplaceEmpty {
                     finishedWithoutUpstream = true
                     return
                 }
-                if receivedUpstream {
+                if !receivedUpstream {
                     _ = downstream.receive(output)
                 }
                 downstream.receive(completion: .finished)

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceEmpty.swift
@@ -37,7 +37,8 @@ extension Publishers {
         /// Use `Never` if this `Publisher` does not publish errors.
         public typealias Failure = Upstream.Failure
 
-        /// The element to deliver when the upstream publisher finishes without delivering any elements.
+        /// The element to deliver when the upstream publisher finishes
+        /// without delivering any elements.
         public let output: Upstream.Output
 
         /// The publisher from which this publisher receives elements.
@@ -48,7 +49,8 @@ extension Publishers {
             self.output = output
         }
 
-        /// This function is called to attach the specified `Subscriber` to this `Publisher` by `subscribe(_:)`
+        /// This function is called to attach the specified `Subscriber`
+        /// to this `Publisher` by `subscribe(_:)`
         ///
         /// - SeeAlso: `subscribe(_:)`
         /// - Parameters:

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -1,0 +1,105 @@
+//
+//  ReplaceEmptyTests.swift
+//  OpenCombine
+//
+//  Created by Joseph Spadafora on 12/10/19.
+//
+
+import XCTest
+
+#if OPENCOMBINE_COMPATIBILITY_TEST
+import Combine
+#else
+import OpenCombine
+#endif
+
+@available(macOS 10.15, iOS 13.0, *)
+final class ReplaceEmptyTests: XCTestCase {
+    func testEmptySubscription() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: nil,
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 15) }
+        )
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
+    }
+
+    func testError() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .max(1),
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 42) }
+        )
+
+        helper.publisher.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .completion(.failure(.oops))])
+    }
+
+    func testEndWithoutValueReplacesCorrectly() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .max(1),
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 42) }
+        )
+
+        helper.publisher.send(completion: .finished)
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(42),
+                                                 .completion(.finished)])
+    }
+
+    func testNoValueIsReplacedIfEndsWithoutEmpty() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .max(1),
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 42) }
+        )
+
+        XCTAssertEqual(helper.publisher.send(3), .none)
+        helper.publisher.send(completion: .finished)
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(3),
+                                                 .completion(.finished)])
+    }
+
+  func testSendingValueAndThenError() {
+      let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                      initialDemand: .max(1),
+                                      receiveValueDemand: .max(1),
+                                      createSut: { $0.replaceEmpty(with: 42) })
+
+      XCTAssertEqual(helper.publisher.send(8), .max(1))
+      helper.publisher.send(completion: .failure(TestingError.oops))
+
+      XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                               .value(8),
+                                               .completion(.failure(.oops))])
+  }
+
+    func testFailingBeforeDemanding() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: nil,
+                                        receiveValueDemand: .max(1),
+                                        createSut: { $0.replaceEmpty(with: 42) })
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
+
+        helper.publisher.send(completion: .failure(TestingError.oops))
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .completion(.failure(.oops))])
+
+        helper.downstreamSubscription?.request(.unlimited)
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .completion(.failure(.oops))])
+
+        XCTAssertEqual(helper.publisher.send(-1), .none)
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .completion(.failure(.oops))])
+    }
+}

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -236,4 +236,33 @@ final class ReplaceEmptyTests: XCTestCase {
                                                      .cancelled])
         XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
     }
+
+    func testReceiveSubscriptionTwice() throws {
+        let helper = OperatorTestHelper(
+            publisherType: CustomPublisher.self,
+            initialDemand: nil,
+            receiveValueDemand: .none,
+            createSut: { $0.replaceEmpty(with: 22) }
+        )
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited)])
+
+        let secondSubscription = CustomSubscription()
+
+        try XCTUnwrap(helper.publisher.subscriber)
+            .receive(subscription: secondSubscription)
+
+        XCTAssertEqual(secondSubscription.history, [.cancelled])
+
+        try XCTUnwrap(helper.publisher.subscriber)
+            .receive(subscription: helper.subscription)
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited), .cancelled])
+
+        try XCTUnwrap(helper.downstreamSubscription).cancel()
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited),
+                                                     .cancelled,
+                                                     .cancelled])
+    }
 }

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -265,4 +265,13 @@ final class ReplaceEmptyTests: XCTestCase {
                                                      .cancelled,
                                                      .cancelled])
     }
+
+    func testReplaceEmptyReflection() throws {
+        try testReflection(parentInput: Int.self,
+                           parentFailure: Error.self,
+                           description: "ReplaceEmpty",
+                           customMirror: childrenIsEmpty,
+                           playgroundDescription: "ReplaceEmpty",
+                           { $0.replaceEmpty(with: 0) })
+    }
 }

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -103,6 +103,18 @@ final class ReplaceEmptyTests: XCTestCase {
                                                  .completion(.failure(.oops))])
     }
 
+    func testUpstreamCompletesEmptyBeforeDownstreamRequests() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: nil,
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 22) })
+        helper.publisher.send(completion: .finished)
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
+
+        helper.subscription.request(.max(3))
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
+    }
+
     // MARK: - Basic Behavior
     func testBasicBehavior() {
         let helper = OperatorTestHelper(publisherType: CustomPublisher.self,

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -113,6 +113,11 @@ final class ReplaceEmptyTests: XCTestCase {
 
         helper.subscription.request(.max(3))
         XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
+
+        helper.downstreamSubscription?.request(.max(1))
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(22),
+                                                 .completion(.finished)])
     }
 
     // MARK: - Basic Behavior

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -274,4 +274,51 @@ final class ReplaceEmptyTests: XCTestCase {
                            playgroundDescription: "ReplaceEmpty",
                            { $0.replaceEmpty(with: 0) })
     }
+
+    func testCrashesWhenRequestedZeroDemand() {
+        let helper = OperatorTestHelper(
+            publisherType: CustomPublisher.self,
+            initialDemand: nil,
+            receiveValueDemand: .none,
+            createSut: { $0.replaceEmpty(with: 9) }
+        )
+
+        assertCrashes {
+            helper.downstreamSubscription?.request(.none)
+        }
+    }
+
+    func testReplaceEmptyReceiveValueBeforeSubscription() {
+        testReceiveValueBeforeSubscription(value: 213,
+                                           expected: .history([], demand: .none)) {
+            $0.replaceEmpty(with: 742)
+        }
+    }
+
+    func testReplaceEmptyReceiveCompletionBeforeSubscription() {
+        testReceiveCompletionBeforeSubscription(inputType: Int.self,
+                                                expected: .history([])) {
+            $0.replaceEmpty(with: -14)
+        }
+    }
+
+    func testReplaceEmptyRequestBeforeSubscription() {
+        testRequestBeforeSubscription(inputType: Int.self, shouldCrash: false) {
+            $0.replaceEmpty(with: 19)
+        }
+    }
+
+    func testReplaceEmptyCancelBeforeSubscription() {
+        testCancelBeforeSubscription(inputType: Int.self, shouldCrash: false) {
+            $0.replaceEmpty(with: 1337)
+        }
+    }
+
+    func testReplaceEmptyLifecycle() throws {
+        // TODO: Fix this test to match combine behavior
+        try testLifecycle(sendValue: 31,
+                          cancellingSubscriptionReleasesSubscriber: false,
+                          finishingIsPassedThrough: false,
+                          { $0.replaceEmpty(with: 13) })
+    }
 }

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -332,7 +332,6 @@ final class ReplaceEmptyTests: XCTestCase {
     }
 
     func testReplaceEmptyLifecycle() throws {
-        // TODO: Fix this test to match combine behavior
         try testLifecycle(sendValue: 31,
                           cancellingSubscriptionReleasesSubscriber: false,
                           finishingIsPassedThrough: false,

--- a/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ReplaceEmptyTests.swift
@@ -67,19 +67,19 @@ final class ReplaceEmptyTests: XCTestCase {
                                                  .completion(.finished)])
     }
 
-  func testSendingValueAndThenError() {
-      let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
-                                      initialDemand: .max(1),
-                                      receiveValueDemand: .max(1),
-                                      createSut: { $0.replaceEmpty(with: 42) })
+    func testSendingValueAndThenError() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .max(1),
+                                        receiveValueDemand: .max(1),
+                                        createSut: { $0.replaceEmpty(with: 42) })
 
-      XCTAssertEqual(helper.publisher.send(8), .max(1))
-      helper.publisher.send(completion: .failure(TestingError.oops))
+        XCTAssertEqual(helper.publisher.send(8), .max(1))
+        helper.publisher.send(completion: .failure(TestingError.oops))
 
-      XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
-                                               .value(8),
-                                               .completion(.failure(.oops))])
-  }
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(8),
+                                                 .completion(.failure(.oops))])
+    }
 
     func testFailingBeforeDemanding() {
         let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
@@ -101,5 +101,139 @@ final class ReplaceEmptyTests: XCTestCase {
         XCTAssertEqual(helper.publisher.send(-1), .none)
         XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
                                                  .completion(.failure(.oops))])
+    }
+
+    // MARK: - Basic Behavior
+    func testBasicBehavior() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .unlimited,
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 22) })
+        XCTAssertEqual(helper.publisher.send(2), .none)
+        XCTAssertEqual(helper.publisher.send(4), .none)
+        XCTAssertEqual(helper.publisher.send(6), .none)
+        XCTAssertEqual(helper.publisher.send(7), .none)
+        XCTAssertEqual(helper.publisher.send(8), .none)
+        XCTAssertEqual(helper.publisher.send(9), .none)
+        helper.publisher.send(completion: .finished)
+        XCTAssertEqual(helper.publisher.send(10), .none)
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(2),
+                                                 .value(4),
+                                                 .value(6),
+                                                 .value(7),
+                                                 .value(8),
+                                                 .value(9),
+                                                 .completion(.finished)])
+    }
+
+    func testDemand() throws {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .max(42),
+                                        receiveValueDemand: .max(4),
+                                        createSut: { $0.replaceEmpty(with: 832) })
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited)])
+
+        XCTAssertEqual(helper.publisher.send(0), .max(4))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited)])
+
+        XCTAssertEqual(helper.publisher.send(2), .max(4))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited)])
+
+        try XCTUnwrap(helper.downstreamSubscription).request(.max(95))
+        try XCTUnwrap(helper.downstreamSubscription).request(.max(5))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5))])
+
+        XCTAssertEqual(helper.publisher.send(3), .max(4))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5))])
+
+        try XCTUnwrap(helper.downstreamSubscription).request(.max(121))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5)),
+                                                     .requested(.max(121))])
+
+        XCTAssertEqual(helper.publisher.send(7), .max(4))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5)),
+                                                     .requested(.max(121))])
+
+        try XCTUnwrap(helper.downstreamSubscription).cancel()
+        try XCTUnwrap(helper.downstreamSubscription).cancel()
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5)),
+                                                     .requested(.max(121)),
+                                                     .cancelled])
+
+        try XCTUnwrap(helper.downstreamSubscription).request(.max(50))
+        XCTAssertEqual(helper.subscription.history, [.requested(.max(42)),
+                                                     .requested(.unlimited),
+                                                     .requested(.max(95)),
+                                                     .requested(.max(5)),
+                                                     .requested(.max(121)),
+                                                     .cancelled])
+
+        XCTAssertEqual(helper.publisher.send(8), .none)
+    }
+
+    func testImmediateCompletion() {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .unlimited,
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: 33) })
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited),
+                                                     .requested(.unlimited)])
+        helper.publisher.send(completion: .finished)
+        helper.publisher.send(completion: .finished)
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited),
+                                                     .requested(.unlimited)])
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(33),
+                                                 .completion(.finished)])
+
+        helper.publisher.send(completion: .failure(.oops))
+        helper.publisher.send(completion: .failure(.oops))
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty"),
+                                                 .value(33),
+                                                 .completion(.finished)])
+    }
+
+    func testCancelAlreadyCancelled() throws {
+        let helper = OperatorTestHelper(publisherType: CustomPublisher.self,
+                                        initialDemand: .unlimited,
+                                        receiveValueDemand: .none,
+                                        createSut: { $0.replaceEmpty(with: -7) })
+
+        try XCTUnwrap(helper.downstreamSubscription).cancel()
+        try XCTUnwrap(helper.downstreamSubscription).request(.unlimited)
+        try XCTUnwrap(helper.downstreamSubscription).cancel()
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited),
+                                                     .requested(.unlimited),
+                                                     .cancelled])
+
+        helper.publisher.send(completion: .failure(.oops))
+        helper.publisher.send(completion: .finished)
+
+        XCTAssertEqual(helper.subscription.history, [.requested(.unlimited),
+                                                     .requested(.unlimited),
+                                                     .cancelled])
+        XCTAssertEqual(helper.tracking.history, [.subscription("ReplaceEmpty")])
     }
 }


### PR DESCRIPTION
Hey @broadwaylamb.  I saw that we still needed ReplaceError so i decided to tackle it.  I based a lot of the usage of the `lock` on one of the other files, but it would be good to look that part over specifically since I haven't worked very much with locks in my day to day coding.  Let me know if there's anything missing.