### PR TITLE
Update for Xcode 11.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2
 jobs:
-  "Execute tests on macOS 10.15.0 (Xcode 11.2.0, Swift 5.1.2)":
+  "Execute tests on macOS 10.15.0 (Xcode 11.3.0, Swift 5.1.3)":
     macos:
-      xcode: "11.2.0"
+      xcode: "11.3.0"
     environment:
-      SWIFT_VERSION: "5.1.2"
+      SWIFT_VERSION: "5.1.3"
     steps:
       - checkout
       - run:
@@ -60,35 +60,35 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash) -D DerivedData
 
-  "Execute compatibility tests on iOS 13.2.2 (Xcode 11.2.0, Swift 5.1.2)":
+  "Execute compatibility tests on iOS 13.3 (Xcode 11.3.0, Swift 5.1.3)":
     macos:
-      xcode: "11.2.0"
+      xcode: "11.3.0"
     environment:
-      SWIFT_VERSION: "5.1.2"
+      SWIFT_VERSION: "5.1.3"
     steps:
       - checkout
       - run:
           name: Generating Xcode project
           command: make generate-compatibility-xcodeproj
       - run:
-          name: Building for testing on iOS 13.2.2 with xcodebuild
+          name: Building for testing on iOS 13.3 with xcodebuild
           command: |
             set -o pipefail \
               && xcodebuild build-for-testing \
                    -scheme OpenCombine-Package \
-                   -destination "platform=iOS Simulator,name=iPhone 11,OS=13.2.2" \
+                   -destination "platform=iOS Simulator,name=iPhone 11,OS=13.3" \
                    -derivedDataPath DerivedData \
               | tee xcodebuild_build-for-testing.log \
               | xcpretty
       - store_artifacts:
           path: xcodebuild_build-for-testing.log
       - run:
-          name: Testing against Combine on iOS 13.2.2 with xcodebuild
+          name: Testing against Combine on iOS 13.3 with xcodebuild
           command: |
             set -o pipefail \
               && xcodebuild test-without-building \
                    -scheme OpenCombine-Package \
-                   -destination "platform=iOS Simulator,name=iPhone 11,OS=13.2.2" \
+                   -destination "platform=iOS Simulator,name=iPhone 11,OS=13.3" \
                    -derivedDataPath DerivedData \
               | tee xcodebuild_test-without-building.log \
               | xcpretty --report junit -o build/reports/results.xml
@@ -217,7 +217,7 @@ jobs:
 
   "Run SwiftLint and Danger":
     macos:
-      xcode: "11.2.0"
+      xcode: "11.3.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "1"
     steps:
@@ -236,7 +236,7 @@ jobs:
 
   "Run Pod spec lint":
     macos:
-      xcode: "11.2.0"
+      xcode: "11.3.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "1"
     steps:
@@ -250,10 +250,10 @@ workflows:
   version: 2
   "OpenCombine: execute tests on macOS":
     jobs:
-      - "Execute tests on macOS 10.15.0 (Xcode 11.2.0, Swift 5.1.2)"
+      - "Execute tests on macOS 10.15.0 (Xcode 11.3.0, Swift 5.1.3)"
   "OpenCombine: execute compatibility tests":
     jobs:
-      - "Execute compatibility tests on iOS 13.2.2 (Xcode 11.2.0, Swift 5.1.2)"
+      - "Execute compatibility tests on iOS 13.3 (Xcode 11.3.0, Swift 5.1.3)"
   "OpenCombine: execute tests on iOS":
     jobs:
       - "Execute tests on iOS 9.3 (Xcode 10.2.1, Swift 5.0.1)"

--- a/Sources/OpenCombine/CurrentValueSubject.swift
+++ b/Sources/OpenCombine/CurrentValueSubject.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 11.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A subject that wraps a single value and publishes a new element whenever the value
 /// changes.
 public final class CurrentValueSubject<Output, Failure: Error>: Subject {

--- a/Sources/OpenCombine/Future.swift
+++ b/Sources/OpenCombine/Future.swift
@@ -5,10 +5,6 @@
 //  Created by Max Desiatov on 24/11/2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A publisher that eventually produces one value and then finishes or fails.
 public final class Future<Output, Failure>: Publisher where Failure: Error {
 

--- a/Sources/OpenCombine/Helpers/FilterProducer.swift
+++ b/Sources/OpenCombine/Helpers/FilterProducer.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 23.10.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A helper class that acts like both subscriber and subscription.
 ///
 /// Filter-like operators send an instance of their `Inner` class that is subclass

--- a/Sources/OpenCombine/Helpers/ReduceProducer.swift
+++ b/Sources/OpenCombine/Helpers/ReduceProducer.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 22.09.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A helper class that acts like both subscriber and subscription.
 ///
 /// Reduce-like operators send an instance of their `Inner` class that is subclass

--- a/Sources/OpenCombine/Helpers/SubjectSubscriber.swift
+++ b/Sources/OpenCombine/Helpers/SubjectSubscriber.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 16/09/2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 // NOTE: This class has been audited for thread safety.
 internal final class SubjectSubscriber<Downstream: Subject>
     : Subscriber,

--- a/Sources/OpenCombine/PassthroughSubject.swift
+++ b/Sources/OpenCombine/PassthroughSubject.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 11.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A subject that passes along values and completion.
 ///
 /// Use a `PassthroughSubject` in unit tests when you want a publisher than can publish

--- a/Sources/OpenCombine/Publishers/Publishers.Autoconnect.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Autoconnect.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 18/09/2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension ConnectablePublisher {
 
     /// Automates the process of connecting or disconnecting from this connectable

--- a/Sources/OpenCombine/Publishers/Publishers.Concatenate.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Concatenate.swift
@@ -145,9 +145,7 @@ extension Publishers.Concatenate {
 
         private let lock = UnfairLock.allocate()
 
-        // ??? This lock is non-recursive in Combine, but it should be!
-        // (FB7404824 if Apple folks are watching)
-        private let downstreamLock = UnfairLock.allocate()
+        private let downstreamLock = UnfairRecursiveLock.allocate()
 
         fileprivate init(downstream: Downstream, suffix: Suffix) {
             self.downstream = downstream

--- a/Sources/OpenCombine/Publishers/Publishers.Drop.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Drop.swift
@@ -5,10 +5,6 @@
 //  Created by Sven Weidauer on 03.10.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
     /// Omits the specified number of elements before republishing subsequent elements.
     ///

--- a/Sources/OpenCombine/Publishers/Publishers.DropWhile.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.DropWhile.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 16.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Omits elements from the upstream publisher until a given closure returns false,

--- a/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.FlatMap.swift
@@ -4,10 +4,6 @@
 //  Created by Eric Patey on 16.08.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
     /// Transforms all elements from an upstream publisher into a new or existing
     /// publisher.
@@ -92,10 +88,9 @@ extension Publishers.FlatMap {
         /// by the `downstreamLock`.
         private let lock = UnfairLock.allocate()
 
-        // Must be recursive lock. Probably a bug in Combine.
         /// All the calls to the downstream subscriber should be made with this lock
         /// acquired.
-        private let downstreamLock = UnfairLock.allocate()
+        private let downstreamLock = UnfairRecursiveLock.allocate()
 
         private let downstream: Downstream
 

--- a/Sources/OpenCombine/Publishers/Publishers.HandleEvents.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.HandleEvents.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Performs the specified closures when publisher events occur.

--- a/Sources/OpenCombine/Publishers/Publishers.IgnoreOutput.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.IgnoreOutput.swift
@@ -4,10 +4,6 @@
 //  Created by Eric Patey on 16.08.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Ingores all upstream elements, but passes along a completion

--- a/Sources/OpenCombine/Publishers/Publishers.Map.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Map.swift
@@ -5,10 +5,6 @@
 //  Created by Anton Nazarov on 25.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Transforms all elements from the upstream publisher with a provided closure.

--- a/Sources/OpenCombine/Publishers/Publishers.MeasureInterval.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.MeasureInterval.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Measures and emits the time interval between events received from an upstream

--- a/Sources/OpenCombine/Publishers/Publishers.Multicast.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Multicast.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 14.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Applies a closure to create a subject that delivers elements to subscribers.

--- a/Sources/OpenCombine/Publishers/Publishers.Output.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Output.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 24.10.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Republishes elements up to the specified maximum count.

--- a/Sources/OpenCombine/Publishers/Publishers.Print.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Print.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 16.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Prints log messages for all publishing events.

--- a/Sources/OpenCombine/Publishers/Publishers.ReplaceError.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.ReplaceError.swift
@@ -5,10 +5,6 @@
 //  Created by Bogdan Vlad on 8/29/19.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
     /// Replaces any errors in the stream with the provided element.
     ///

--- a/Sources/OpenCombine/Publishers/Publishers.Scan.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Scan.swift
@@ -4,10 +4,6 @@
 //  Created by Eric Patey on 26.08.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Transforms elements from the upstream publisher by providing the current element

--- a/Sources/OpenCombine/Publishers/Publishers.Sequence.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Sequence.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 19.06.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publishers {
 
     /// A publisher that publishes a given sequence of elements.

--- a/Sources/OpenCombine/Publishers/Publishers.SubscribeOn.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.SubscribeOn.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 02.12.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 extension Publisher {
 
     /// Specifies the scheduler on which to perform subscribe, cancel, and request

--- a/Sources/OpenCombine/Publishers/Record.swift
+++ b/Sources/OpenCombine/Publishers/Record.swift
@@ -5,10 +5,6 @@
 //  Created by Sergej Jaskiewicz on 12.11.2019.
 //
 
-#if canImport(COpenCombineHelpers)
-import COpenCombineHelpers
-#endif
-
 /// A publisher that allows for recording a series of inputs and a completion for later
 /// playback to each subscriber.
 public struct Record<Output, Failure: Error>: Publisher {

--- a/Tests/OpenCombineTests/Helpers/TestReflection.swift
+++ b/Tests/OpenCombineTests/Helpers/TestReflection.swift
@@ -133,7 +133,7 @@ internal func testSubscriptionReflection<Sut: Publisher>(
     customMirror customMirrorPredicate: ((Mirror) -> Bool)?,
     playgroundDescription: String,
     sut: Sut
-) throws where Sut.Output: Equatable {
+) throws {
     let tracking = TrackingSubscriberBase<Sut.Output, Sut.Failure>()
     sut.subscribe(tracking)
 

--- a/Tests/OpenCombineTests/ObservableObjectPublisherTests.swift
+++ b/Tests/OpenCombineTests/ObservableObjectPublisherTests.swift
@@ -23,22 +23,27 @@ final class ObservableObjectPublisherTests: XCTestCase {
             receiveSubscription: { downstreamSubscription1 = $0 }
         )
         publisher.subscribe(tracking1)
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
         downstreamSubscription1?.request(.max(1))
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
         publisher.send()
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
                                       .signal])
         publisher.send()
         publisher.send()
         downstreamSubscription1?.request(.max(3))
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
+                                      .signal,
+                                      .signal,
                                       .signal])
         publisher.send()
         publisher.send()
         publisher.send()
         publisher.send()
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
+                                      .signal,
+                                      .signal,
+                                      .signal,
                                       .signal,
                                       .signal,
                                       .signal,
@@ -49,28 +54,48 @@ final class ObservableObjectPublisherTests: XCTestCase {
             receiveSubscription: { $0.request(.unlimited) }
         )
         publisher.subscribe(tracking2)
-        tracking2.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking2.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
 
         publisher.send()
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
+                                      .signal,
+                                      .signal,
+                                      .signal,
                                       .signal,
                                       .signal,
                                       .signal,
                                       .signal,
                                       .signal])
-        tracking2.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking2.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
                                       .signal])
 
         downstreamSubscription1?.cancel()
         publisher.send()
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
+                                      .signal,
+                                      .signal,
+                                      .signal,
                                       .signal,
                                       .signal,
                                       .signal,
                                       .signal,
                                       .signal])
-        tracking2.assertHistoryEqual([.subscription("PassthroughSubject"),
+        tracking2.assertHistoryEqual([.subscription("ObservableObjectPublisher"),
                                       .signal,
                                       .signal])
+
+        tracking1.cancel()
+        tracking2.cancel()
+    }
+
+    func testObservableObjectPublisherReflection() throws {
+        try testSubscriptionReflection(
+            description: "ObservableObjectPublisher",
+            customMirror: expectedChildren(
+                ("downstream", .contains("TrackingSubscriberBase"))
+            ),
+            playgroundDescription: "ObservableObjectPublisher",
+            sut: ObservableObjectPublisher()
+        )
     }
 }

--- a/Tests/OpenCombineTests/PublishedTests.swift
+++ b/Tests/OpenCombineTests/PublishedTests.swift
@@ -88,11 +88,11 @@ final class PublishedTests: XCTestCase {
             receiveSubscription: { downstreamSubscription = $0 }
         )
         testObject.objectWillChange.subscribe(tracking1)
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
         downstreamSubscription?.request(.max(2))
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
         testObject.state = 100
-        tracking1.assertHistoryEqual([.subscription("PassthroughSubject")])
+        tracking1.assertHistoryEqual([.subscription("ObservableObjectPublisher")])
     }
 }
 

--- a/Tests/OpenCombineTests/PublisherTests/ConcatenateTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ConcatenateTests.swift
@@ -359,9 +359,21 @@ final class ConcatenateTests: XCTestCase {
             helper.publisher.send(completion: .failure(.oops))
         }
 
-        assertCrashes {
-            helper.publisher.send(completion: .failure(.oops))
-        }
+        helper.publisher.send(completion: .failure(.oops))
+
+        XCTAssertEqual(helper.tracking.history, [.subscription("Concatenate"),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops)),
+                                                 .completion(.failure(.oops))])
+        XCTAssertEqual(helper.subscription.history, [])
     }
 
     func testHelperMethods() {

--- a/Tests/OpenCombineTests/PublisherTests/SubscribeOnTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/SubscribeOnTests.swift
@@ -206,7 +206,10 @@ final class SubscribeOnTests: XCTestCase {
             $0.subscribe(on: ImmediateScheduler.shared)
         }
 
+        var recursionCounter = 5
         helper.subscription.onRequest = { _ in
+            if recursionCounter == 0 { return }
+            recursionCounter -= 1
             helper.downstreamSubscription?.request(.unlimited)
         }
 


### PR DESCRIPTION
- Send subscription synchronously in `ReceiveOn` and `Delay` operators
- Some locks made recursive, as they should be
- `ObservableObjectPublisher` doesn't use `PassthroughSubject` under the hood anymore