### PR TITLE
Expose OpenCombineFoundation target as a product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .library(name: "OpenCombine", targets: ["OpenCombine"]),
         .library(name: "OpenCombineDispatch", targets: ["OpenCombineDispatch"]),
+        .library(name: "OpenCombineFoundation", targets: ["OpenCombineFoundation"]),
     ],
     targets: [
         .target(name: "COpenCombineHelpers"),


### PR DESCRIPTION
This should fix `import OpenCombineFoundation` issue reported in #124.