### PR TITLE
work around SR-11680

### DIFF
--- a/Sources/COpenCombineHelpers/COpenCombineHelpers.cpp
+++ b/Sources/COpenCombineHelpers/COpenCombineHelpers.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <system_error>
 #include <pthread.h>
+#include <signal.h>
 
 #ifdef __APPLE__
 #include <os/lock.h>
@@ -233,6 +234,10 @@ void opencombine_unfair_lock_dealloc(OpenCombineUnfairLock lock) {
 
 void opencombine_unfair_recursive_lock_dealloc(OpenCombineUnfairRecursiveLock lock) {
     return delete static_cast<PlatformIndependentMutex*>(lock.opaque);
+}
+
+void opencombine_stop_in_debugger(void) {
+    raise(SIGTRAP);
 }
 
 } // extern "C"

--- a/Sources/COpenCombineHelpers/include/COpenCombineHelpers.h
+++ b/Sources/COpenCombineHelpers/include/COpenCombineHelpers.h
@@ -9,18 +9,11 @@
 #define COPENCOMBINEHELPERS_H
 
 #include <stdint.h>
-#include <signal.h>
 
 #if __has_attribute(swift_name)
 # define OPENCOMBINE_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
 #else
 # define OPENCOMBINE_SWIFT_NAME(_name)
-#endif
-
-#if __has_attribute(always_inline)
-# define OPENCOMBINE_ALWAYS_INLINE __attribute__((always_inline))
-#else
-# define OPENCOMBINE_ALWAYS_INLINE
 #endif
 
 #ifdef __cplusplus
@@ -77,12 +70,7 @@ void opencombine_unfair_recursive_lock_dealloc(OpenCombineUnfairRecursiveLock lo
 
 #pragma mark - Breakpoint
 
-OPENCOMBINE_ALWAYS_INLINE
-inline void opencombine_stop_in_debugger(void) OPENCOMBINE_SWIFT_NAME(__stopInDebugger());
-
-void opencombine_stop_in_debugger(void) {
-    raise(SIGTRAP);
-}
+void opencombine_stop_in_debugger(void) OPENCOMBINE_SWIFT_NAME(__stopInDebugger());
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
The Swift bug report: https://bugs.swift.org/browse/SR-11680

Swift nightly toolchains are available here: https://swift.org/download/

The Swift nightly toolchains cannot build OpenCombine. Here's why:

1.  The COpenCombineHelpers target defines a non-static function
    (opencombine_stop_in_debugger) in a header file. This function is
    emitted in the target's IR, but not in the target's TBD.

2.  Swift nightly toolchains have assertions enabled, so they use the
    `-validate-tbd-against-ir=missing` build setting. This build setting
    makes the compiler fail if the TBD doesn't match the IR.

This commit turns off the build setting for the OpenCombine target.