### PR TITLE
Document an expected crash

### DIFF
--- a/Tests/OpenCombineTests/PublisherTests/ResultPublisherTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/ResultPublisherTests.swift
@@ -148,7 +148,7 @@ final class ResultPublisherTests: XCTestCase {
     {
       class ExternallyTriggered: Subscriber {
         typealias Input = Int
-        typealias Failure = Never
+        typealias Failure = TestingError
 
         let combineIdentifier = CombineIdentifier()
         var sub: Subscription?
@@ -161,13 +161,16 @@ final class ResultPublisherTests: XCTestCase {
         func cancel() { sub?.cancel() }
       }
 
-      for i in 1...1000
-      {
-        let pub = Result<Int, Never>.OCombine.Publisher(i)
-        let sub = ExternallyTriggeredSubscriber()
-        pub.subscribe(sub)
-        DispatchQueue.global(qos: .utility).async { sub.request() }
-        DispatchQueue.global(qos: .utility).async { sub.cancel() }
+      assertCrashes {
+        for i in 1...10000 {
+          let pub = makePublisher(i)
+//          let pub = Optional.OCombine.Publisher(i)
+//          let pub = Just(i)
+          let sub = ExternallyTriggered()
+          pub.subscribe(sub)
+          DispatchQueue.global(qos: .utility).async { sub.request() }
+          DispatchQueue.global(qos: .utility).async { sub.cancel() }
+        }
       }
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/broadwaylamb/OpenCombine/issues/157.

Adds the test with an `assertCrashes` block, to monitor if and when the official Combine stops crashing in this situation (FB7722681).

Note that `Just` and `Optional.Publisher` exhibit the same behaviour.