### PR TITLE
Test with Swift 5.2 on Ubuntu 18.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,11 +161,11 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash) -D DerivedData
 
-  "Execute tests on Ubuntu 18.04 (Swift 5.2.4)":
+  "Execute tests on Ubuntu 18.04 (Swift 5.2)":
     docker:
-      - image: swift:5.2.4-bionic
+      - image: swift:5.2-bionic
     environment:
-      SWIFT_VERSION: "5.2.4"
+      SWIFT_VERSION: "5.2"
     steps:
       - checkout
       - run:
@@ -265,7 +265,7 @@ workflows:
       - "Execute tests on iOS 9.3 (Xcode 10.2.1, Swift 5.0.1)"
   "OpenCombine: execute tests on Linux":
     jobs:
-      - "Execute tests on Ubuntu 18.04 (Swift 5.2.4)"
+      - "Execute tests on Ubuntu 18.04 (Swift 5.2)"
   "OpenCombine: run SwiftLint and Danger":
     jobs:
       - "Run SwiftLint and Danger"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,11 +161,11 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash) -D DerivedData
 
-  "Execute tests on Ubuntu 18.04 (Swift 5.1.1)":
+  "Execute tests on Ubuntu 18.04 (Swift 5.2.4)":
     docker:
-      - image: swift:5.1.1-bionic
+      - image: swift:5.2.4-bionic
     environment:
-      SWIFT_VERSION: "5.1.1"
+      SWIFT_VERSION: "5.2.4"
     steps:
       - checkout
       - run:
@@ -265,7 +265,7 @@ workflows:
       - "Execute tests on iOS 9.3 (Xcode 10.2.1, Swift 5.0.1)"
   "OpenCombine: execute tests on Linux":
     jobs:
-      - "Execute tests on Ubuntu 18.04 (Swift 5.1.1)"
+      - "Execute tests on Ubuntu 18.04 (Swift 5.2.4)"
   "OpenCombine: run SwiftLint and Danger":
     jobs:
       - "Run SwiftLint and Danger"


### PR DESCRIPTION
I don't think it makes much sense to test on an older version of Swift on Ubuntu. Since we tested only a single version, I've updated that to the latest available, but let me know if you'd like to test with multiple Swift versions on Linux.

As a sidenote, I hope we could also switch to GitHub Actions in the future. Circle CI seems to be annoyingly slow.