### PR TITLE
Fix a build error on linux: `kCFStringEncodingUTF8` is not defined.

### DIFF
--- a/Sources/OpenCombineFoundation/Timer+Publisher.swift
+++ b/Sources/OpenCombineFoundation/Timer+Publisher.swift
@@ -337,11 +337,19 @@ extension RunLoop.Mode {
         return CFRunLoopMode(rawValue as CFString)
 #else
         return rawValue.withCString {
-            CFStringCreateWithCString(
+#if swift(>=5.3)
+            return CFStringCreateWithCString(
                 nil,
                 $0,
                 CFStringBuiltInEncodings.UTF8.rawValue
             )
+#else
+            return CFStringCreateWithCString(
+                nil,
+                $0,
+                CFStringEncoding(kCFStringEncodingUTF8)
+            )
+#endif
         }
 #endif
     }

--- a/Sources/OpenCombineFoundation/Timer+Publisher.swift
+++ b/Sources/OpenCombineFoundation/Timer+Publisher.swift
@@ -338,18 +338,16 @@ extension RunLoop.Mode {
 #else
         return rawValue.withCString {
 #if swift(>=5.3)
-            return CFStringCreateWithCString(
-                nil,
-                $0,
-                CFStringBuiltInEncodings.UTF8.rawValue
-            )
+          let encoding = CFStringBuiltInEncodings.UTF8.rawValue
 #else
-            return CFStringCreateWithCString(
-                nil,
-                $0,
-                CFStringEncoding(kCFStringEncodingUTF8)
-            )
-#endif
+          let encoding = CFStringEncoding(kCFStringEncodingUTF8)
+#endif // swift(>=5.3)
+
+          return CFStringCreateWithCString(
+              nil,
+              $0,
+              encoding
+          )
         }
 #endif
     }

--- a/Sources/OpenCombineFoundation/Timer+Publisher.swift
+++ b/Sources/OpenCombineFoundation/Timer+Publisher.swift
@@ -340,7 +340,7 @@ extension RunLoop.Mode {
             CFStringCreateWithCString(
                 nil,
                 $0,
-                CFStringEncoding(kCFStringEncodingUTF8)
+                CFStringBuiltInEncodings.UTF8.rawValue
             )
         }
 #endif

--- a/Tests/OpenCombineTests/PublisherTests/CollectTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/CollectTests.swift
@@ -29,7 +29,7 @@ final class CollectTests: XCTestCase {
 
     func testtestUpstreamFinishesImmediately() {
         ReduceTests.testUpstreamFinishesImmediately(expectedSubscription: "Collect",
-                                                    expectedResult: [],
+                                                    expectedResult: [Int](),
                                                     { $0.collect() })
     }
 


### PR DESCRIPTION
`kCFStringEncodingUTF8` is available in C, but not in swift. I think `CFStringBuiltInEncodings.UTF8.rawValue` is what's intended. However, I didn't take a close look at this code, so please let me know if I'm missing something.

Also fix a type error I was getting in a unit test with Swift 5.3.