### PR TITLE
Use of undeclared type PropertyListEncoder on Swift 5.0

### DIFF
--- a/Sources/OpenCombineFoundation/PropertyListEncoder.swift
+++ b/Sources/OpenCombineFoundation/PropertyListEncoder.swift
@@ -8,7 +8,8 @@
 import Foundation
 import OpenCombine
 
-#if swift(>=5.1)
+// PropertyListEncoder and PropertyListDecoder are unavailable in swift-corelibs-foundation prior to Swift 5.1.
+#if canImport(Darwin) || swift(>=5.1)
 extension PropertyListEncoder: TopLevelEncoder {
   public typealias Output = Data
 }

--- a/Sources/OpenCombineFoundation/PropertyListEncoder.swift
+++ b/Sources/OpenCombineFoundation/PropertyListEncoder.swift
@@ -8,7 +8,8 @@
 import Foundation
 import OpenCombine
 
-// PropertyListEncoder and PropertyListDecoder are unavailable in swift-corelibs-foundation prior to Swift 5.1.
+// PropertyListEncoder and PropertyListDecoder are unavailable in 
+// swift-corelibs-foundation prior to Swift 5.1.
 #if canImport(Darwin) || swift(>=5.1)
 extension PropertyListEncoder: TopLevelEncoder {
   public typealias Output = Data

--- a/Sources/OpenCombineFoundation/PropertyListEncoder.swift
+++ b/Sources/OpenCombineFoundation/PropertyListEncoder.swift
@@ -8,6 +8,7 @@
 import Foundation
 import OpenCombine
 
+#if swift(>=5.1)
 extension PropertyListEncoder: TopLevelEncoder {
   public typealias Output = Data
 }
@@ -15,3 +16,4 @@ extension PropertyListEncoder: TopLevelEncoder {
 extension PropertyListDecoder: TopLevelDecoder {
   public typealias Input = Data
 }
+#endif


### PR DESCRIPTION
`PropertyListEncoder` and `PropertyListDecoder` are both unavailable prior to Swift 5.1, causing a build error for Swift 5.0.

From what I've gathered they're available on the [swift-5.1-branch](https://github.com/apple/swift-corelibs-foundation/blob/swift-5.1-branch/Foundation/PropertyListEncoder.swift), but missing on the [swift-5.0-branch](https://github.com/apple/swift-corelibs-foundation/blob/swift-5.0-branch/Foundation/PropertyListEncoder.swift).