### PR TITLE
Incorrect argument label in call (have 'for:', expected 'forKey:')

### DIFF
--- a/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
+++ b/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
@@ -187,15 +187,11 @@ extension OperationQueue {
             }
 
             private func becomeReady() {
-#if canImport(Darwin)
+// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
+#if canImport(Darwin) || swift(>=5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898
-                willChangeValue(forKey: "isReady")
-#elseif swift(<5.1)
-                // The smart key paths don't work with NSOperation prior to Swift 5.1.
-                // The string key paths work fine everywhere.
-                // https://github.com/apple/swift-corelibs-foundation/blob/swift-5.0-branch/Foundation/Operation.swift
                 willChangeValue(forKey: "isReady")
 #else
                 willChangeValue(for: \.isReady)
@@ -203,15 +199,11 @@ extension OperationQueue {
                 lock.lock()
                 readyFromAfter = true
                 lock.unlock()
-#if canImport(Darwin)
+// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
+#if canImport(Darwin) || swift(>=5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898
-                didChangeValue(forKey: "isReady")
-#elseif swift(<5.1)
-                // The smart key paths don't work with NSOperation prior to Swift 5.1.
-                // The string key paths work fine everywhere.
-                // https://github.com/apple/swift-corelibs-foundation/blob/swift-5.0-branch/Foundation/Operation.swift
                 didChangeValue(forKey: "isReady")
 #else
                 didChangeValue(for: \.isReady)

--- a/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
+++ b/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
@@ -187,7 +187,8 @@ extension OperationQueue {
             }
 
             private func becomeReady() {
-// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
+// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to
+// Swift 5.1.
 #if canImport(Darwin) || swift(<5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
@@ -199,7 +200,8 @@ extension OperationQueue {
                 lock.lock()
                 readyFromAfter = true
                 lock.unlock()
-// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
+// Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to 
+// Swift 5.1.
 #if canImport(Darwin) || swift(<5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.

--- a/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
+++ b/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
@@ -188,7 +188,7 @@ extension OperationQueue {
 
             private func becomeReady() {
 // Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
-#if canImport(Darwin) || swift(>=5.1)
+#if canImport(Darwin) || swift(<5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898

--- a/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
+++ b/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
@@ -192,6 +192,11 @@ extension OperationQueue {
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898
                 willChangeValue(forKey: "isReady")
+#elseif swift(<5.1)
+                // The smart key paths don't work with NSOperation prior to Swift 5.1.
+                // The string key paths work fine everywhere.
+                // https://github.com/apple/swift-corelibs-foundation/blob/swift-5.0-branch/Foundation/Operation.swift
+                willChangeValue(forKey: "isReady")
 #else
                 willChangeValue(for: \.isReady)
 #endif
@@ -202,6 +207,11 @@ extension OperationQueue {
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898
+                didChangeValue(forKey: "isReady")
+#elseif swift(<5.1)
+                // The smart key paths don't work with NSOperation prior to Swift 5.1.
+                // The string key paths work fine everywhere.
+                // https://github.com/apple/swift-corelibs-foundation/blob/swift-5.0-branch/Foundation/Operation.swift
                 didChangeValue(forKey: "isReady")
 #else
                 didChangeValue(for: \.isReady)

--- a/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
+++ b/Sources/OpenCombineFoundation/OperationQueue+Scheduler.swift
@@ -200,7 +200,7 @@ extension OperationQueue {
                 readyFromAfter = true
                 lock.unlock()
 // Smart key paths don't work with NSOperation in swift-corelibs-foundation prior to Swift 5.1.
-#if canImport(Darwin) || swift(>=5.1)
+#if canImport(Darwin) || swift(<5.1)
                 // The smart key paths don't work with NSOperation on OS versions prior to
                 // iOS 11. The string key paths work fine everywhere.
                 // https://forums.swift.org/t/keypath-translation-for-kvo-notification-seems-to-not-work-properly-on-ios-10/15898


### PR DESCRIPTION
This pull request relates to #176.