### PR TITLE
Prepare for 0.10.1

### DIFF
--- a/OpenCombine.podspec
+++ b/OpenCombine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "OpenCombine"
-  spec.version       = "0.10.0"
+  spec.version       = "0.10.1"
   spec.summary       = "Open source implementation of Apple's Combine framework for processing values over time."
 
   spec.description   = <<-DESC

--- a/OpenCombineDispatch.podspec
+++ b/OpenCombineDispatch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "OpenCombineDispatch"
-  spec.version       = "0.10.0"
+  spec.version       = "0.10.1"
   spec.summary       = "OpenCombine + Dispatch interoperability"
 
   spec.description   = <<-DESC

--- a/OpenCombineFoundation.podspec
+++ b/OpenCombineFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name          = "OpenCombineFoundation"
-    spec.version       = "0.10.0"
+    spec.version       = "0.10.1"
     spec.summary       = "OpenCombine + OpenCombineFoundation interoperability"
   
     spec.description   = <<-DESC

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To add `OpenCombine` to your [SPM](https://swift.org/package-manager/) package, 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0")
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.1")
 ],
 targets: [
     .target(name: "MyAwesomePackage", dependencies: ["OpenCombine",
@@ -46,9 +46,9 @@ To do so, open Xcode, use **File** → **Swift Packages** → **Add Package Depe
 To add `OpenCombine` to a project using [CocoaPods](https://cocoapods.org/), add `OpenCombine` and `OpenCombineDispatch` to the list of target dependencies in your `Podfile`. 
 
 ```ruby
-pod 'OpenCombine', '~> 0.10'
-pod 'OpenCombineDispatch', '~> 0.10'
-pod 'OpenCombineFoundation', '~> 0.10'
+pod 'OpenCombine', '~> 0.10.1'
+pod 'OpenCombineDispatch', '~> 0.10.1'
+pod 'OpenCombineFoundation', '~> 0.10.1'
 ```
 
 ### Contributing


### PR DESCRIPTION
Bumped version to include fix for build errors (#176 and #177) on linux when using swift 5.0 (swift-corelibs-foundation).