### PR TITLE
Add support for SwiftWasm with CI and tests

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,16 @@
+name: SwiftWasm 
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  carton_wasmer_test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: swiftwasm/swiftwasm-action@v5.3
+

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
             "Publishers/Publishers.Encode.swift.gyb",
             "Publishers/Publishers.MapKeyPath.swift.gyb",
             "Publishers/Publishers.Catch.swift.gyb"
-          ]
+          ],
+          swiftSettings: [.define("WASI", .when(platforms: [.wasi]))]
         ),
         .target(name: "OpenCombineDispatch", dependencies: ["OpenCombine"]),
         .target(
@@ -37,7 +38,10 @@ let package = Package(
             .target(name: "OpenCombineDispatch", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])),
             .target(name: "OpenCombineFoundation", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])),
           ],
-          swiftSettings: [.unsafeFlags(["-enable-testing"])]
+          swiftSettings: [
+            .unsafeFlags(["-enable-testing"]), 
+            .define("WASI", .when(platforms: [.wasi]))
+          ]
         )
     ],
     cxxLanguageStandard: .cxx1z

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .target(
           name: "OpenCombine", 
           dependencies: [
-            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .linux]))
+            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux]))
           ],
           exclude: [
             "Publishers/Publishers.Encode.swift.gyb",

--- a/Package.swift
+++ b/Package.swift
@@ -27,15 +27,15 @@ let package = Package(
           name: "OpenCombineFoundation", 
           dependencies: [
             "OpenCombine",
-            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .linux]))
+            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux]))
           ]
         ),
         .testTarget(
           name: "OpenCombineTests",
           dependencies: [
             "OpenCombine",
-            .target(name: "OpenCombineDispatch", condition: .when(platforms: [.macOS, .linux])),
-            .target(name: "OpenCombineFoundation", condition: .when(platforms: [.macOS, .linux])),
+            .target(name: "OpenCombineDispatch", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])),
+            .target(name: "OpenCombineFoundation", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])),
           ],
           swiftSettings: [.unsafeFlags(["-enable-testing"])]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -11,15 +11,34 @@ let package = Package(
     ],
     targets: [
         .target(name: "COpenCombineHelpers"),
-        .target(name: "OpenCombine", dependencies: ["COpenCombineHelpers"]),
+        .target(
+          name: "OpenCombine", 
+          dependencies: [
+            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .linux]))
+          ],
+          exclude: [
+            "Publishers/Publishers.Encode.swift.gyb",
+            "Publishers/Publishers.MapKeyPath.swift.gyb",
+            "Publishers/Publishers.Catch.swift.gyb"
+          ]
+        ),
         .target(name: "OpenCombineDispatch", dependencies: ["OpenCombine"]),
-        .target(name: "OpenCombineFoundation", dependencies: ["OpenCombine",
-                                                              "COpenCombineHelpers"]),
-        .testTarget(name: "OpenCombineTests",
-                    dependencies: ["OpenCombine",
-                                   "OpenCombineDispatch",
-                                   "OpenCombineFoundation"],
-                    swiftSettings: [.unsafeFlags(["-enable-testing"])])
+        .target(
+          name: "OpenCombineFoundation", 
+          dependencies: [
+            "OpenCombine",
+            .target(name: "COpenCombineHelpers", condition: .when(platforms: [.macOS, .linux]))
+          ]
+        ),
+        .testTarget(
+          name: "OpenCombineTests",
+          dependencies: [
+            "OpenCombine",
+            .target(name: "OpenCombineDispatch", condition: .when(platforms: [.macOS, .linux])),
+            .target(name: "OpenCombineFoundation", condition: .when(platforms: [.macOS, .linux])),
+          ],
+          swiftSettings: [.unsafeFlags(["-enable-testing"])]
+        )
     ],
     cxxLanguageStandard: .cxx1z
 )

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenCombine",
+    products: [
+        .library(name: "OpenCombine", targets: ["OpenCombine"]),
+        .library(name: "OpenCombineDispatch", targets: ["OpenCombineDispatch"]),
+        .library(name: "OpenCombineFoundation", targets: ["OpenCombineFoundation"]),
+    ],
+    targets: [
+        .target(name: "COpenCombineHelpers"),
+        .target(name: "OpenCombine", dependencies: ["COpenCombineHelpers"]),
+        .target(name: "OpenCombineDispatch", dependencies: ["OpenCombine"]),
+        .target(name: "OpenCombineFoundation", dependencies: ["OpenCombine",
+                                                              "COpenCombineHelpers"]),
+        .testTarget(name: "OpenCombineTests",
+                    dependencies: ["OpenCombine",
+                                   "OpenCombineDispatch",
+                                   "OpenCombineFoundation"],
+                    swiftSettings: [.unsafeFlags(["-enable-testing"])])
+    ],
+    cxxLanguageStandard: .cxx1z
+)

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenCombine",
+    products: [
+        .library(name: "OpenCombine", targets: ["OpenCombine"]),
+        .library(name: "OpenCombineDispatch", targets: ["OpenCombineDispatch"]),
+        .library(name: "OpenCombineFoundation", targets: ["OpenCombineFoundation"]),
+    ],
+    targets: [
+        .target(name: "COpenCombineHelpers"),
+        .target(name: "OpenCombine", dependencies: ["COpenCombineHelpers"]),
+        .target(name: "OpenCombineDispatch", dependencies: ["OpenCombine"]),
+        .target(name: "OpenCombineFoundation", dependencies: ["OpenCombine",
+                                                              "COpenCombineHelpers"]),
+        .testTarget(name: "OpenCombineTests",
+                    dependencies: ["OpenCombine",
+                                   "OpenCombineDispatch",
+                                   "OpenCombineFoundation"],
+                    swiftSettings: [.unsafeFlags(["-enable-testing"])])
+    ],
+    cxxLanguageStandard: .cxx1z
+)

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenCombine",
+    products: [
+        .library(name: "OpenCombine", targets: ["OpenCombine"]),
+        .library(name: "OpenCombineDispatch", targets: ["OpenCombineDispatch"]),
+        .library(name: "OpenCombineFoundation", targets: ["OpenCombineFoundation"]),
+    ],
+    targets: [
+        .target(name: "COpenCombineHelpers"),
+        .target(name: "OpenCombine", dependencies: ["COpenCombineHelpers"]),
+        .target(name: "OpenCombineDispatch", dependencies: ["OpenCombine"]),
+        .target(name: "OpenCombineFoundation", dependencies: ["OpenCombine",
+                                                              "COpenCombineHelpers"]),
+        .testTarget(name: "OpenCombineTests",
+                    dependencies: ["OpenCombine",
+                                   "OpenCombineDispatch",
+                                   "OpenCombineFoundation"],
+                    swiftSettings: [.unsafeFlags(["-enable-testing"])])
+    ],
+    cxxLanguageStandard: .cxx1z
+)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenCombine itself does not have any dependencies. Not even Foundation or Dispat
 
 ##### Swift Package Manager
 ###### Swift Package
-To add `OpenCombine` to your [SwiftPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file. `OpenCombineDispatch` and `OpenCombineFoundation` projects are currently not supported on WebAssembly. You should either omit them from the list of your dependencies if your project targets WebAssembly exclusively, or exclude them with [conditional target dependencies](https://github.com/apple/swift-evolution/blob/main/proposals/0273-swiftpm-conditional-target-dependencies.md).
+To add `OpenCombine` to your [SwiftPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file. `OpenCombineDispatch` and `OpenCombineFoundation` products are currently not supported on WebAssembly. If your project targets WebAssembly exclusively, you should omit them from the list of your dependencies. If it targets multiple platforms including WebAssembly, depend on them only on non-WebAssembly platforms with [conditional target dependencies](https://github.com/apple/swift-evolution/blob/main/proposals/0273-swiftpm-conditional-target-dependencies.md).
 
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![OpenCombine](https://circleci.com/gh/OpenCombine/OpenCombine.svg?style=svg)](https://circleci.com/gh/OpenCombine/OpenCombine)
 [![codecov](https://codecov.io/gh/OpenCombine/OpenCombine/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenCombine/OpenCombine)
 ![Language](https://img.shields.io/badge/Swift-5.0-orange.svg)
-![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS-lightgrey.svg)
+![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20Wasm-lightgrey.svg)
 ![Cocoapods](https://img.shields.io/cocoapods/v/OpenCombine?color=blue)
 [<img src="https://img.shields.io/badge/slack-OpenCombine-yellow.svg?logo=slack">](https://join.slack.com/t/opencombine/shared_invite/enQtNzE2MjE5NzkxODI0LTYxMjkzNDUxZWViZWI1Njc2YjBhODgxNjRjOTdkZTcxOGU2ZjJjZjYxMGI3NWZkN2RkNGFmZTUzNmU3MGE2ZWM)
 
 Open-source implementation of Apple's [Combine](https://developer.apple.com/documentation/combine) framework for processing values over time.
 
-The main goal of this project is to provide a compatible, reliable and efficient implementation which can be used on Apple's operating systems before macOS 10.15 and iOS 13, as well as Linux and Windows.
+The main goal of this project is to provide a compatible, reliable and efficient implementation which can be used on Apple's operating systems before macOS 10.15 and iOS 13, as well as Linux and WebAssembly.
 
 ### Installation
 `OpenCombine` contains three public targets: `OpenCombine`, `OpenCombineFoundation` and `OpenCombineDispatch` (the fourth one, `COpenCombineHelpers`, is considered private. Don't import it in your projects).
@@ -17,7 +17,7 @@ OpenCombine itself does not have any dependencies. Not even Foundation or Dispat
 
 ##### Swift Package Manager
 ###### Swift Package
-To add `OpenCombine` to your [SPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file.
+To add `OpenCombine` to your [SwiftPM](https://swift.org/package-manager/) package, add the `OpenCombine` package to the list of package and target dependencies in your `Package.swift` file. `OpenCombineDispatch` and `OpenCombineFoundation` projects are currently not supported on WebAssembly. You should either omit them from the list of your dependencies if your project targets WebAssembly exclusively, or exclude them with [conditional target dependencies](https://github.com/apple/swift-evolution/blob/main/proposals/0273-swiftpm-conditional-target-dependencies.md).
 
 ```swift
 dependencies: [
@@ -31,7 +31,7 @@ targets: [
 ```
 
 ###### Xcode
-`OpenCombine` can also be added as a SPM dependency directly in your Xcode project *(requires Xcode 11 upwards)*.
+`OpenCombine` can also be added as a SwiftPM dependency directly in your Xcode project *(requires Xcode 11 upwards)*.
 
 To do so, open Xcode, use **File** → **Swift Packages** → **Add Package Dependency…**, enter the [repository URL](https://github.com/OpenCombine/OpenCombine.git), choose the latest available version, and activate the checkboxes:
 

--- a/Sources/OpenCombine/CombineIdentifier.swift
+++ b/Sources/OpenCombine/CombineIdentifier.swift
@@ -12,7 +12,7 @@ import COpenCombineHelpers
 #if os(WASI)
 private var __identifier: UInt64 = 0
 func __nextCombineIdentifier() -> UInt64 {
-    __identifier += 1
+    defer { __identifier += 1 }
     return __identifier
 }
 #endif

--- a/Sources/OpenCombine/CombineIdentifier.swift
+++ b/Sources/OpenCombine/CombineIdentifier.swift
@@ -9,13 +9,14 @@
 import COpenCombineHelpers
 #endif
 
-#if os(WASI)
+#if WASI
 private var __identifier: UInt64 = 0
-func __nextCombineIdentifier() -> UInt64 {
+
+internal func __nextCombineIdentifier() -> UInt64 {
     defer { __identifier += 1 }
     return __identifier
 }
-#endif
+#endif // WASI
 
 /// A unique identifier for identifying publisher streams.
 ///

--- a/Sources/OpenCombine/CombineIdentifier.swift
+++ b/Sources/OpenCombine/CombineIdentifier.swift
@@ -9,6 +9,14 @@
 import COpenCombineHelpers
 #endif
 
+#if os(WASI)
+private var __identifier: UInt64 = 0
+func __nextCombineIdentifier() -> UInt64 {
+    __identifier += 1
+    return __identifier
+}
+#endif
+
 /// A unique identifier for identifying publisher streams.
 ///
 /// To conform to `CustomCombineIdentifierConvertible` in a

--- a/Sources/OpenCombine/Helpers/Locking.swift
+++ b/Sources/OpenCombine/Helpers/Locking.swift
@@ -9,22 +9,24 @@
 import COpenCombineHelpers
 #endif
 
+#if swift(>=5.3)
 #if os(WASI)
-struct UnfairLock {
-    public static func allocate() -> UnfairLock { return Self.init() }
-    public func lock() {}
-    public func unlock() {}
-    public func assertOwner() {}
-    public func deallocate() {}
+internal struct __UnfairLock {
+    internal static func allocate() -> UnfairLock { return .init() }
+    internal func lock() {}
+    internal func unlock() {}
+    internal func assertOwner() {}
+    internal func deallocate() {}
 }
 
-struct UnfairRecursiveLock {
-    public static func allocate() -> UnfairRecursiveLock { return Self.init() }
-    public func lock() {}
-    public func unlock() {}
-    public func deallocate() {}
+internal struct __UnfairRecursiveLock {
+    internal static func allocate() -> UnfairRecursiveLock { return .init() }
+    internal func lock() {}
+    internal func unlock() {}
+    internal func deallocate() {}
 }
-#else
+#endif // os(WASI)
+#endif // swift(>=5.3)
+
 internal typealias UnfairLock = __UnfairLock
 internal typealias UnfairRecursiveLock = __UnfairRecursiveLock
-#endif

--- a/Sources/OpenCombine/Helpers/Locking.swift
+++ b/Sources/OpenCombine/Helpers/Locking.swift
@@ -9,5 +9,22 @@
 import COpenCombineHelpers
 #endif
 
+#if os(WASI)
+struct UnfairLock {
+    public static func allocate() -> UnfairLock { return Self.init() }
+    public func lock() {}
+    public func unlock() {}
+    public func assertOwner() {}
+    public func deallocate() {}
+}
+
+struct UnfairRecursiveLock {
+    public static func allocate() -> UnfairRecursiveLock { return Self.init() }
+    public func lock() {}
+    public func unlock() {}
+    public func deallocate() {}
+}
+#else
 internal typealias UnfairLock = __UnfairLock
 internal typealias UnfairRecursiveLock = __UnfairRecursiveLock
+#endif

--- a/Sources/OpenCombine/Helpers/Locking.swift
+++ b/Sources/OpenCombine/Helpers/Locking.swift
@@ -9,9 +9,8 @@
 import COpenCombineHelpers
 #endif
 
-#if swift(>=5.3)
-#if os(WASI)
-internal struct __UnfairLock {
+#if WASI
+internal struct __UnfairLock { // swiftlint:disable:this type_name
     internal static func allocate() -> UnfairLock { return .init() }
     internal func lock() {}
     internal func unlock() {}
@@ -19,14 +18,13 @@ internal struct __UnfairLock {
     internal func deallocate() {}
 }
 
-internal struct __UnfairRecursiveLock {
+internal struct __UnfairRecursiveLock { // swiftlint:disable:this type_name
     internal static func allocate() -> UnfairRecursiveLock { return .init() }
     internal func lock() {}
     internal func unlock() {}
     internal func deallocate() {}
 }
-#endif // os(WASI)
-#endif // swift(>=5.3)
+#endif // WASI
 
 internal typealias UnfairLock = __UnfairLock
 internal typealias UnfairRecursiveLock = __UnfairRecursiveLock

--- a/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
+#if !os(WASI)
+
 #if canImport(COpenCombineHelpers)
 import COpenCombineHelpers
 #endif
@@ -225,3 +227,5 @@ extension Publishers.Breakpoint {
         var playgroundDescription: Any { return description }
     }
 }
+
+#endif

--- a/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
@@ -228,4 +228,4 @@ extension Publishers.Breakpoint {
     }
 }
 
-#endif
+#endif // !WASI

--- a/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
+++ b/Sources/OpenCombine/Publishers/Publishers.Breakpoint.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 #if canImport(COpenCombineHelpers)
 import COpenCombineHelpers

--- a/Tests/OpenCombineTests/DispatchTests/DispatchQueueSchedulerTests.swift
+++ b/Tests/OpenCombineTests/DispatchTests/DispatchQueueSchedulerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 26.08.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import Dispatch
 import XCTest
@@ -581,4 +581,4 @@ private struct KeyedWrapper<Value: Codable & Equatable>: Codable, Equatable {
     let value: Value
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/DispatchTests/DispatchQueueSchedulerTests.swift
+++ b/Tests/OpenCombineTests/DispatchTests/DispatchQueueSchedulerTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 26.08.2019.
 //
 
+#if !os(WASI)
+
 import Dispatch
 import XCTest
 
@@ -570,7 +572,7 @@ private typealias Scheduler = DispatchQueue.OCombine
 private let mainScheduler = DispatchQueue.main.ocombine
 private let backgroundScheduler = DispatchQueue.global(qos: .background).ocombine
 
-#endif
+#endif // OPENCOMBINE_COMPATIBILITY_TEST || !canImport(Combine)
 
 @available(macOS 10.15, iOS 13.0, *)
 private typealias Stride = Scheduler.SchedulerTimeType.Stride
@@ -578,3 +580,5 @@ private typealias Stride = Scheduler.SchedulerTimeType.Stride
 private struct KeyedWrapper<Value: Codable & Equatable>: Codable, Equatable {
     let value: Value
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/JSONDecoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/JSONDecoderTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import Foundation
 import XCTest
@@ -64,4 +64,4 @@ final class JSONDecoderTests: XCTestCase {
     }
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/JSONDecoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/JSONDecoderTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -61,3 +63,5 @@ final class JSONDecoderTests: XCTestCase {
         cancellable.cancel()
     }
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/JSONEncoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/JSONEncoderTests.swift
@@ -5,6 +5,7 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
+#if !os(WASI)
 import Foundation
 import XCTest
 
@@ -65,3 +66,5 @@ final class JSONEncoderTests: XCTestCase {
         cancellable.cancel()
     }
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/JSONEncoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/JSONEncoderTests.swift
@@ -5,7 +5,8 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
+
 import Foundation
 import XCTest
 
@@ -67,4 +68,4 @@ final class JSONEncoderTests: XCTestCase {
     }
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/NotificationCenterTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/NotificationCenterTests.swift
@@ -5,6 +5,7 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
+#if !os(WASI)
 import Foundation
 import XCTest
 
@@ -630,4 +631,6 @@ extension Notification.Name {
         self.init(rawValue: rawValue)
     }
 }
-#endif
+#endif // !canImport(Darwin) && swift(<5.1)
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/NotificationCenterTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/NotificationCenterTests.swift
@@ -5,7 +5,8 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
+
 import Foundation
 import XCTest
 
@@ -633,4 +634,4 @@ extension Notification.Name {
 }
 #endif // !canImport(Darwin) && swift(<5.1)
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/OperationQueueSchedulerTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/OperationQueueSchedulerTests.swift
@@ -5,7 +5,9 @@
 //  Created by Sergej Jaskiewicz on 14.06.2020.
 //
 
-#if !os(WASI)
+// OperationQueue has serious bugs in swift-corelibs-foundation prior to Swift 5.3.
+// (see https://github.com/apple/swift-corelibs-foundation/pull/2779)
+#if canImport(Darwin) || swift(>=5.3) && !WASI // TEST_DISCOVERY_CONDITION
 
 import Foundation
 import XCTest
@@ -16,10 +18,6 @@ import Combine
 import OpenCombine
 import OpenCombineFoundation
 #endif
-
-// OperationQueue has serious bugs in swift-corelibs-foundation prior to Swift 5.3.
-// (see https://github.com/apple/swift-corelibs-foundation/pull/2779)
-#if canImport(Darwin) || swift(>=5.3) // TEST_DISCOVERY_CONDITION
 
 @available(macOS 10.15, iOS 13.0, *)
 final class OperationQueueSchedulerTests: XCTestCase {
@@ -473,6 +471,4 @@ private final class TestOperationQueue: OperationQueue {
 #endif // canImport(Darwin)
 }
 
-#endif // canImport(Darwin) || swift(>=5.3)
-
-#endif // os(WASI)
+#endif // canImport(Darwin) || swift(>=5.3) && !WASI

--- a/Tests/OpenCombineTests/FoundationTests/OperationQueueSchedulerTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/OperationQueueSchedulerTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 14.06.2020.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -472,3 +474,5 @@ private final class TestOperationQueue: OperationQueue {
 }
 
 #endif // canImport(Darwin) || swift(>=5.3)
+
+#endif // os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/PropertyListDecoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/PropertyListDecoderTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -80,3 +82,5 @@ final class PropertyListDecoderTests: XCTestCase {
 }
 
 #endif // canImport(Darwin) || swift(>=5.1)
+
+#endif // os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/PropertyListDecoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/PropertyListDecoderTests.swift
@@ -5,7 +5,9 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
-#if !os(WASI)
+// PropertyListEncoder and PropertyListDecoder are unavailable in
+// swift-corelibs-foundation prior to Swift 5.1.
+#if canImport(Darwin) || swift(>=5.1) && !WASI // TEST_DISCOVERY_CONDITION
 
 import Foundation
 import XCTest
@@ -16,10 +18,6 @@ import Combine
 import OpenCombine
 import OpenCombineFoundation
 #endif
-
-// PropertyListEncoder and PropertyListDecoder are unavailable in
-// swift-corelibs-foundation prior to Swift 5.1.
-#if canImport(Darwin) || swift(>=5.1) // TEST_DISCOVERY_CONDITION
 
 @available(macOS 10.15, iOS 13.0, *)
 final class PropertyListDecoderTests: XCTestCase {
@@ -81,6 +79,4 @@ final class PropertyListDecoderTests: XCTestCase {
     }
 }
 
-#endif // canImport(Darwin) || swift(>=5.1)
-
-#endif // os(WASI)
+#endif // canImport(Darwin) || swift(>=5.1) && !WASI

--- a/Tests/OpenCombineTests/FoundationTests/PropertyListEncoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/PropertyListEncoderTests.swift
@@ -5,7 +5,9 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
-#if !os(WASI)
+// PropertyListEncoder and PropertyListDecoder are unavailable in
+// swift-corelibs-foundation prior to Swift 5.1.
+#if canImport(Darwin) || swift(>=5.1) && !WASI // TEST_DISCOVERY_CONDITION
 
 import Foundation
 import XCTest
@@ -16,10 +18,6 @@ import Combine
 import OpenCombine
 import OpenCombineFoundation
 #endif
-
-// PropertyListEncoder and PropertyListDecoder are unavailable in
-// swift-corelibs-foundation prior to Swift 5.1.
-#if canImport(Darwin) || swift(>=5.1) // TEST_DISCOVERY_CONDITION
 
 @available(macOS 10.15, iOS 13.0, *)
 final class PropertyListEncoderTests: XCTestCase {
@@ -86,6 +84,4 @@ final class PropertyListEncoderTests: XCTestCase {
     }
 }
 
-#endif // canImport(Darwin) || swift(>=5.1)
-
-#endif // !os(WASI)
+#endif // canImport(Darwin) || swift(>=5.1) && !WASI

--- a/Tests/OpenCombineTests/FoundationTests/PropertyListEncoderTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/PropertyListEncoderTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 10.12.2019.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -85,3 +87,5 @@ final class PropertyListEncoderTests: XCTestCase {
 }
 
 #endif // canImport(Darwin) || swift(>=5.1)
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/RunLoopSchedulerTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/RunLoopSchedulerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 14.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import Foundation
 import XCTest
@@ -630,4 +630,4 @@ extension RunLoopScheduler.SchedulerTimeType: DateBackedSchedulerTimeType {}
 
 extension RunLoopScheduler: RunLoopLikeScheduler {}
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/RunLoopSchedulerTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/RunLoopSchedulerTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 14.12.2019.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -627,3 +629,5 @@ extension RunLoopScheduler.SchedulerTimeType.Stride: TimeIntervalBackedScheduler
 extension RunLoopScheduler.SchedulerTimeType: DateBackedSchedulerTimeType {}
 
 extension RunLoopScheduler: RunLoopLikeScheduler {}
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/TimerPublisherTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/TimerPublisherTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 23.06.2020.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import Foundation
 import XCTest
@@ -217,4 +217,4 @@ private typealias TimerPublisher = Timer.TimerPublisher
 private typealias TimerPublisher = Timer.OCombine.TimerPublisher
 #endif
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/TimerPublisherTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/TimerPublisherTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 23.06.2020.
 //
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -214,3 +216,5 @@ private typealias TimerPublisher = Timer.TimerPublisher
 #else
 private typealias TimerPublisher = Timer.OCombine.TimerPublisher
 #endif
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/FoundationTests/URLSessionTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/URLSessionTests.swift
@@ -7,7 +7,7 @@
 
 // swiftlint:disable multiline_arguments
 
-#if !os(WASI)
+#if !WASI
 
 import Foundation
 import XCTest
@@ -723,8 +723,8 @@ private func makePublisher(
 ) -> URLSession.OCombine.DataTaskPublisher {
     return session.ocombine.dataTaskPublisher(for: request)
 }
-#endif
+#endif // OPENCOMBINE_COMPATIBILITY_TEST || !canImport(Combine)
 
 #endif // canImport(Darwin)
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/FoundationTests/URLSessionTests.swift
+++ b/Tests/OpenCombineTests/FoundationTests/URLSessionTests.swift
@@ -7,6 +7,8 @@
 
 // swiftlint:disable multiline_arguments
 
+#if !os(WASI)
+
 import Foundation
 import XCTest
 
@@ -724,3 +726,5 @@ private func makePublisher(
 #endif
 
 #endif // canImport(Darwin)
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/Helpers/AssertCrashes.swift
+++ b/Tests/OpenCombineTests/Helpers/AssertCrashes.swift
@@ -29,7 +29,7 @@ extension XCTest {
     // Taken from swift-corelibs-foundation and slightly modified for OpenCombine
     @available(macOS 10.13, iOS 8.0, *)
     func assertCrashes(within block: () throws -> Void) rethrows {
-#if !Xcode && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(WASI)
+#if !Xcode && !os(iOS) && !os(watchOS) && !os(tvOS) && !WASI
         let childProcessEnvVariable = "OPENCOMBINE_TEST_PERFORM_ASSERT_CRASHES_BLOCKS"
         let childProcessEnvVariableOnValue = "YES"
 
@@ -82,6 +82,6 @@ extension XCTest {
                 printDiagnostics()
             }
         }
-#endif
+#endif // !Xcode && !os(iOS) && !os(watchOS) && !os(tvOS) && !WASI
     }
 }

--- a/Tests/OpenCombineTests/Helpers/AssertCrashes.swift
+++ b/Tests/OpenCombineTests/Helpers/AssertCrashes.swift
@@ -29,7 +29,7 @@ extension XCTest {
     // Taken from swift-corelibs-foundation and slightly modified for OpenCombine
     @available(macOS 10.13, iOS 8.0, *)
     func assertCrashes(within block: () throws -> Void) rethrows {
-#if !Xcode && !os(iOS) && !os(watchOS) && !os(tvOS)
+#if !Xcode && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(WASI)
         let childProcessEnvVariable = "OPENCOMBINE_TEST_PERFORM_ASSERT_CRASHES_BLOCKS"
         let childProcessEnvVariableOnValue = "YES"
 

--- a/Tests/OpenCombineTests/Helpers/ExecuteOnBackgroundThread.swift
+++ b/Tests/OpenCombineTests/Helpers/ExecuteOnBackgroundThread.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 04.02.2020.
 //
 
+#if !os(WASI)
+
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -81,3 +83,5 @@ func executeOnBackgroundThread<ResultType>(
         }
     }
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/Helpers/ExecuteOnBackgroundThread.swift
+++ b/Tests/OpenCombineTests/Helpers/ExecuteOnBackgroundThread.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 04.02.2020.
 //
 
-#if !os(WASI)
+#if !WASI
 
 #if canImport(Darwin)
 import Darwin
@@ -84,4 +84,4 @@ func executeOnBackgroundThread<ResultType>(
     }
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/Helpers/TestingThreadSafety.swift
+++ b/Tests/OpenCombineTests/Helpers/TestingThreadSafety.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 11.06.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import Dispatch
 import Foundation
@@ -106,4 +106,4 @@ func XCTAssertEqual<Value: Equatable>(
     XCTAssertEqual(try expression1().value, try expression2(), message())
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/Helpers/TestingThreadSafety.swift
+++ b/Tests/OpenCombineTests/Helpers/TestingThreadSafety.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 11.06.2019.
 //
 
+#if !os(WASI)
+
 import Dispatch
 import Foundation
 import XCTest
@@ -103,3 +105,5 @@ func XCTAssertEqual<Value: Equatable>(
 ) {
     XCTAssertEqual(try expression1().value, try expression2(), message())
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/PublisherTests/BreakpointTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/BreakpointTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
+#if !os(WASI)
+
 import XCTest
 
 #if OPENCOMBINE_COMPATIBILITY_TEST
@@ -170,3 +172,5 @@ final class BreakpointTests: XCTestCase {
                            { $0.breakpointOnError() })
     }
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/PublisherTests/BreakpointTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/BreakpointTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 03.12.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import XCTest
 
@@ -173,4 +173,4 @@ final class BreakpointTests: XCTestCase {
     }
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
@@ -5,8 +5,6 @@
 //  Created by Sergej Jaskiewicz on 17.06.2019.
 //
 
-#if !WASI
-
 import XCTest
 
 #if OPENCOMBINE_COMPATIBILITY_TEST
@@ -428,5 +426,3 @@ private func stealingStdout(to stream: HistoryStream, _ body: () -> Void) {
     body()
     _playgroundPrintHook = oldValue
 }
-
-#endif // !WASI

--- a/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
@@ -5,7 +5,7 @@
 //  Created by Sergej Jaskiewicz on 17.06.2019.
 //
 
-#if !os(WASI)
+#if !WASI
 
 import XCTest
 
@@ -429,4 +429,4 @@ private func stealingStdout(to stream: HistoryStream, _ body: () -> Void) {
     _playgroundPrintHook = oldValue
 }
 
-#endif // !os(WASI)
+#endif // !WASI

--- a/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
+++ b/Tests/OpenCombineTests/PublisherTests/PrintTests.swift
@@ -5,6 +5,8 @@
 //  Created by Sergej Jaskiewicz on 17.06.2019.
 //
 
+#if !os(WASI)
+
 import XCTest
 
 #if OPENCOMBINE_COMPATIBILITY_TEST
@@ -405,7 +407,6 @@ final class PrintTests: XCTestCase {
 }
 
 private final class HistoryStream: TextOutputStream {
-
     let output = Atomic([String]())
 
     func write(_ string: String) {
@@ -427,3 +428,5 @@ private func stealingStdout(to stream: HistoryStream, _ body: () -> Void) {
     body()
     _playgroundPrintHook = oldValue
 }
+
+#endif // !os(WASI)

--- a/Tests/OpenCombineTests/SubscribersTests/SubscribersDemandTests.swift
+++ b/Tests/OpenCombineTests/SubscribersTests/SubscribersDemandTests.swift
@@ -197,6 +197,7 @@ final class SubscribersDemandTests: XCTestCase {
         XCTAssertEqual(Subscribers.Demand.unlimited.description, "unlimited")
     }
 
+#if !os(WASI)
     func testEncodeDecodeJSON() throws {
         try testEncodeDecode(
             encoder: JSONEncoder(),
@@ -315,6 +316,8 @@ final class SubscribersDemandTests: XCTestCase {
 
         XCTAssertEqual(decodedIllFormedTooBig.value.description, "unlimited")
     }
+
+    #endif // !os(WASI)
 }
 
 @available(macOS 10.15, iOS 13.0, *)

--- a/Tests/OpenCombineTests/SubscribersTests/SubscribersDemandTests.swift
+++ b/Tests/OpenCombineTests/SubscribersTests/SubscribersDemandTests.swift
@@ -197,7 +197,7 @@ final class SubscribersDemandTests: XCTestCase {
         XCTAssertEqual(Subscribers.Demand.unlimited.description, "unlimited")
     }
 
-#if !os(WASI)
+#if !WASI
     func testEncodeDecodeJSON() throws {
         try testEncodeDecode(
             encoder: JSONEncoder(),
@@ -317,7 +317,7 @@ final class SubscribersDemandTests: XCTestCase {
         XCTAssertEqual(decodedIllFormedTooBig.value.description, "unlimited")
     }
 
-    #endif // !os(WASI)
+#endif // !WASI
 }
 
 @available(macOS 10.15, iOS 13.0, *)


### PR DESCRIPTION
WebAssembly support for atomics and multi-threading isn't fully standardized yet, and it not supported in SwiftWasm at the moment. Because of this `Dispatch` is unavailable, and all Combine-related Foundation stuff is unavailable too. Tests related to this are disabled. Locking functions are replaced with no-op shims.
