### PR TITLE
Fixed Timer(timeInterval:,repeats:,block:) not accounting timeInterval for the first fire date.

### DIFF
--- a/Sources/OpenCombineFoundation/Helpers/Portability.swift
+++ b/Sources/OpenCombineFoundation/Helpers/Portability.swift
@@ -60,7 +60,7 @@ internal struct Timer {
         repeats: Bool,
         block: @escaping (Timer) -> Void
     ) {
-        self.init(fire: Date(), interval: timeInterval, repeats: repeats, block: block)
+        self.init(fire: Date() + timeInterval, interval: timeInterval, repeats: repeats, block: block)
     }
 
     internal var tolerance: TimeInterval {

--- a/Sources/OpenCombineFoundation/Helpers/Portability.swift
+++ b/Sources/OpenCombineFoundation/Helpers/Portability.swift
@@ -60,7 +60,12 @@ internal struct Timer {
         repeats: Bool,
         block: @escaping (Timer) -> Void
     ) {
-        self.init(fire: Date() + timeInterval, interval: timeInterval, repeats: repeats, block: block)
+        self.init(
+            fire: Date() + timeInterval,
+            interval: timeInterval,
+            repeats: repeats,
+            block: block
+        )
     }
 
     internal var tolerance: TimeInterval {


### PR DESCRIPTION
https://github.com/OpenCombine/OpenCombine/blob/master/Sources/OpenCombineFoundation/Helpers/Portability.swift#L58-L64

It looks like this was a typo/something overlooked, but basically, this `fire: Date()` breaks at least every timer publisher like `Timer.publish(every: timeInterval, on: .main, in: .default)`, as it basically results in the *first* event fired immediately vs in timeInterval. (Just in case, no, Combine does not fire that extra event).