### PR TITLE
support library evolution

### DIFF
--- a/Sources/OpenCombine/AnyPublisher.swift
+++ b/Sources/OpenCombine/AnyPublisher.swift
@@ -62,6 +62,7 @@ extension Publisher {
 ///
 /// You can use OpenCombine’s `eraseToAnyPublisher()` operator to wrap a publisher with
 /// `AnyPublisher`.
+@frozen
 public struct AnyPublisher<Output, Failure: Error>
   : CustomStringConvertible,
     CustomPlaygroundDisplayConvertible
@@ -112,7 +113,7 @@ extension AnyPublisher: Publisher {
 
 /// A type-erasing base class. Its concrete subclass is generic over the underlying
 /// publisher.
-@usableFromInline
+@usableFromInline @_fixed_layout
 internal class PublisherBoxBase<Output, Failure: Error>: Publisher {
 
     @inlinable
@@ -126,7 +127,7 @@ internal class PublisherBoxBase<Output, Failure: Error>: Publisher {
     }
 }
 
-@usableFromInline
+@usableFromInline @_fixed_layout
 internal final class PublisherBox<PublisherType: Publisher>
     : PublisherBoxBase<PublisherType.Output, PublisherType.Failure>
 {

--- a/Sources/OpenCombine/AnySubscriber.swift
+++ b/Sources/OpenCombine/AnySubscriber.swift
@@ -11,6 +11,7 @@
 /// expose. You can also use `AnySubscriber` to create a custom subscriber by providing
 /// closures for the methods defined in `Subscriber`, rather than implementing
 /// `Subscriber` directly.
+@frozen
 public struct AnySubscriber<Input, Failure: Error>: Subscriber,
                                                     CustomStringConvertible,
                                                     CustomReflectable,
@@ -130,7 +131,7 @@ public struct AnySubscriber<Input, Failure: Error>: Subscriber,
 
 /// A type-erasing base class. Its concrete subclass is generic over the underlying
 /// subscriber.
-@usableFromInline
+@usableFromInline @_fixed_layout
 internal class AnySubscriberBase<Input, Failure: Error>: Subscriber {
 
     @inline(__always)
@@ -157,7 +158,7 @@ internal class AnySubscriberBase<Input, Failure: Error>: Subscriber {
     }
 }
 
-@usableFromInline
+@usableFromInline @_fixed_layout
 internal final class AnySubscriberBox<Base: Subscriber>
     : AnySubscriberBase<Base.Input, Base.Failure>
 {
@@ -188,7 +189,7 @@ internal final class AnySubscriberBox<Base: Subscriber>
     }
 }
 
-@usableFromInline
+@usableFromInline @_fixed_layout
 internal final class ClosureBasedAnySubscriber<Input, Failure: Error>
     : AnySubscriberBase<Input, Failure>
 {

--- a/Sources/OpenCombine/ImmediateScheduler.swift
+++ b/Sources/OpenCombine/ImmediateScheduler.swift
@@ -54,7 +54,6 @@ public struct ImmediateScheduler: Scheduler {
             public var magnitude: Int
 
             /// Creates an immediate scheduler time interval from the given time interval.
-            @inlinable
             public init(_ value: Int) {
                 magnitude = value
             }

--- a/Sources/OpenCombine/Subscribers/Subscribers.Demand.swift
+++ b/Sources/OpenCombine/Subscribers/Subscribers.Demand.swift
@@ -11,6 +11,7 @@ extension Subscribers {
 
     /// A requested number of items, sent to a publisher from a subscriber through
     /// the subscription.
+    @frozen
     public struct Demand: Equatable,
                           Comparable,
                           Hashable,


### PR DESCRIPTION
These changes are made according to the `.swiftinterface` of Apples's Official Combine framework.

So it should not affect the performance or correctness of OpenCombine.

With these changes, OpenCombine can be distributed as a static binary framework