### PR TITLE
Add support for Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let supportedPlatforms: [Platform] = [
     .tvOS,
     .linux,
     .android,
-    // Disable Windows because of https://bugs.swift.org/browse/SR-13817
-    // .windows,
+    .windows,
     .wasi,
 ]
 


### PR DESCRIPTION
It looks like the bug mentioned in `Package.swift` is fixed in Xcode 12.2 or later (https://bugs.swift.org/browse/SR-13817). Shouldn't we support Windows then?