### PR TITLE
Migrate SwiftLint checks from CircleCI to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ workflows:
       - "Execute tests on Ubuntu 18.04 (Swift 5.2)"
       - "Execute tests on Ubuntu 18.04 (Swift 5.3)"
       - "Execute tests on Ubuntu 18.04 (Swift 5.4)"
+      - "Execute tests on Ubuntu 18.04 (Swift 5.5)"
   "OpenCombine: validate podspec files":
     jobs:
       - "Run Pod spec lint"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,24 +205,12 @@ jobs:
       SWIFT_VERSION: "5.4"
     <<: *ubuntu_tests_steps
 
-  "Run SwiftLint and Danger":
-    macos:
-      xcode: "11.4.0"
+  "Execute tests on Ubuntu 18.04 (Swift 5.5)":
+    docker:
+      - image: swift:5.5-bionic
     environment:
-      HOMEBREW_NO_AUTO_UPDATE: "1"
-    steps:
-      - checkout
-      - run:
-          name: Install SwiftLint
-          command: |
-            brew install swiftlint
-      - run:
-          name: Install danger-swift
-          command: |
-            brew install danger/tap/danger-swift
-      - run:
-          name: Run danger-swift
-          command: danger-swift ci
+      SWIFT_VERSION: "5.5"
+    <<: *ubuntu_tests_steps
 
   "Run Pod spec lint":
     macos:
@@ -253,9 +241,6 @@ workflows:
       - "Execute tests on Ubuntu 18.04 (Swift 5.2)"
       - "Execute tests on Ubuntu 18.04 (Swift 5.3)"
       - "Execute tests on Ubuntu 18.04 (Swift 5.4)"
-  "OpenCombine: run SwiftLint and Danger":
-    jobs:
-      - "Run SwiftLint and Danger"
   "OpenCombine: validate podspec files":
     jobs:
       - "Run Pod spec lint"

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,24 @@
+name: SwiftLint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/swiftlint.yml"
+      - ".swiftlint.yml"
+      - "**/*.swift"
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      # Fetch current versions of files
+      - name: Fetch base ref
+        run: |
+          git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
+      # Diff pull request to current files, then SwiftLint changed files
+      - name: GitHub Action for SwiftLint
+        uses: mayk-it/action-swiftlint@3.2.2
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
+          DIFF_HEAD: HEAD


### PR DESCRIPTION
SwiftLint integration with Danger no longer works on CircleCI. I'm migrating it to GitHub Actions in a way that's known to work in other repositories.

I've also added a job for testing with Swift 5.5 on Ubuntu 18.04.