### PR TITLE
Add Primary Associated Types to align with Combine

### DIFF
--- a/Sources/OpenCombine/ConnectablePublisher.swift
+++ b/Sources/OpenCombine/ConnectablePublisher.swift
@@ -14,7 +14,7 @@
 ///
 /// Use `makeConnectable()` to create a `ConnectablePublisher` from any publisher whose
 /// failure type is `Never`.
-public protocol ConnectablePublisher: Publisher {
+public protocol ConnectablePublisher<Output, Failure>: Publisher {
 
     /// Connects to the publisher, allowing it to produce elements, and returns
     /// an instance with which to cancel publishing.

--- a/Sources/OpenCombine/Publisher.swift
+++ b/Sources/OpenCombine/Publisher.swift
@@ -41,7 +41,7 @@
 /// - Add the `@Published` annotation to a property of one of your own types. In doing so,
 ///   the property gains a publisher that emits an event whenever the property’s value
 ///   changes. See the `Published` type for an example of this approach.
-public protocol Publisher {
+public protocol Publisher<Output, Failure> {
 
     /// The kind of values published by this publisher.
     associatedtype Output

--- a/Sources/OpenCombine/Scheduler.swift
+++ b/Sources/OpenCombine/Scheduler.swift
@@ -38,7 +38,7 @@ public protocol SchedulerTimeIntervalConvertible {
 /// with the convenience functions like `.milliseconds(500)`. Schedulers can accept
 /// options to control how they execute the actions passed to them. These options may
 /// control factors like which threads or dispatch queues execute the actions.
-public protocol Scheduler {
+public protocol Scheduler<SchedulerTimeType> {
 
     /// Describes an instant in time for this scheduler.
     associatedtype SchedulerTimeType: Strideable

--- a/Sources/OpenCombine/Subject.swift
+++ b/Sources/OpenCombine/Subject.swift
@@ -10,7 +10,7 @@
 /// A subject is a publisher that you can use to ”inject” values into a stream, by calling
 /// its `send()` method. This can be useful for adapting existing imperative code to the
 /// Combine model.
-public protocol Subject: AnyObject, Publisher {
+public protocol Subject<Output, Failure>: AnyObject, Publisher {
 
     /// Sends a value to the subscriber.
     ///

--- a/Sources/OpenCombine/Subscriber.swift
+++ b/Sources/OpenCombine/Subscriber.swift
@@ -28,7 +28,7 @@
 ///   it receives a completion signal and each time it receives a new element.
 /// - `assign(to:on:)` writes each newly-received value to a property identified by
 ///   a key path on a given instance.
-public protocol Subscriber: CustomCombineIdentifierConvertible {
+public protocol Subscriber<Input, Failure>: CustomCombineIdentifierConvertible {
 
     /// The kind of values this subscriber receives.
     associatedtype Input


### PR DESCRIPTION
Bug/issue #, if applicable: 

Close #237 

## Summary

Add Primary Associated Types to align with iOS 16/macOS 13's Combine SDK.

## Dependencies

Swift 5.7 / Xcode 14.0 is required

> https://github.com/apple/swift-evolution/blob/main/proposals/0358-primary-associated-types-in-stdlib.md

## Testing

None
