### PR TITLE
COpenCOmbineHelpers: add an explicit modulemap

### DIFF
--- a/Sources/COpenCombineHelpers/include/module.modulemap
+++ b/Sources/COpenCombineHelpers/include/module.modulemap
@@ -1,0 +1,3 @@
+module COpenCombineHelpers {
+  header "COpenCombineHelpers.h"
+}


### PR DESCRIPTION
Introduce an explicit modulemap as not all build systems will write out a modulemap for you.  Add the explicit modulemap to allow building with alternative build systems.