### PR TITLE
Update Subscribers.Demand

### DIFF
--- a/Sources/OpenCombine/AnySubscriber.swift
+++ b/Sources/OpenCombine/AnySubscriber.swift
@@ -193,13 +193,13 @@ internal final class ClosureBasedAnySubscriber<Input, Failure: Error>
     : AnySubscriberBase<Input, Failure>
 {
     @usableFromInline
-    internal let receiveSubscriptionThunk: (Subscription) -> Void
+    final internal let receiveSubscriptionThunk: (Subscription) -> Void
 
     @usableFromInline
-    internal let receiveValueThunk: (Input) -> Subscribers.Demand
+    final internal let receiveValueThunk: (Input) -> Subscribers.Demand
 
     @usableFromInline
-    internal let receiveCompletionThunk: (Subscribers.Completion<Failure>) -> Void
+    final internal let receiveCompletionThunk: (Subscribers.Completion<Failure>) -> Void
 
     @inlinable
     internal init(_ rcvSubscription: @escaping (Subscription) -> Void,

--- a/Sources/OpenCombine/Helpers/Violations.swift
+++ b/Sources/OpenCombine/Helpers/Violations.swift
@@ -24,10 +24,10 @@ internal func abstractMethod(file: StaticString = #file, line: UInt = #line) -> 
 }
 
 extension Subscribers.Demand {
-    internal func assertNonZero(file: StaticString = #file,
-                                line: UInt = #line) {
-        if self == .none {
-            fatalError("API Violation: demand must not be zero", file: file, line: line)
-        }
+    @_transparent
+    @inline(__always)
+    internal func assertNonZero() {
+        precondition(rawValue <= 0x8000_0000_0000_0000)
+        precondition(rawValue > 0)
     }
 }

--- a/Tests/OpenCombineTests/HelpersTests/ViolationsTests.swift
+++ b/Tests/OpenCombineTests/HelpersTests/ViolationsTests.swift
@@ -1,0 +1,25 @@
+//
+//  ViolationsTests.swift
+//
+//
+//  Created by Kyle on 2023/11/18.
+//
+
+#if !OPENCOMBINE_COMPATIBILITY_TEST
+@testable import OpenCombine
+import XCTest
+
+final class ViolationsTests: XCTestCase {
+    func testDemandAssertNonZero() {
+        let d0 = Subscribers.Demand.none
+        let d1 = Subscribers.Demand.max(1)
+        let d2 = Subscribers.Demand.unlimited
+
+        assertCrashes {
+            d0.assertNonZero()
+        }
+        d1.assertNonZero()
+        d2.assertNonZero()
+    }
+}
+#endif


### PR DESCRIPTION
1. Align the Subscribers.Demand's implementation with Xcode 15 SDK Combine’s swiftinterface

`Int(x)` -> `numericCast(xx)`.

2. Update assertNonZero implementation and add test case for it.